### PR TITLE
Fixed exception handling when unknown MIDI command arrives

### DIFF
--- a/src/renderer/main/panels/MidiMonitor/MidiMonitor.store.js
+++ b/src/renderer/main/panels/MidiMonitor/MidiMonitor.store.js
@@ -177,7 +177,14 @@ function getCommand(int_value) {
     return cmd;
   } catch (e) {
     console.log("MIDI message parsing error: " + e);
-    return undefined;
+    return {
+      name: "Unknown",
+      short: int_value.toString(),
+      params: {
+        p1: { name: "P1", short: "P1" },
+        p2: { name: "P2", short: "P2" },
+      },
+    };
   }
 }
 


### PR DESCRIPTION
The issue of App crashing was fixed when an unknown MIDI command arrives. The display of these MIDI commands were not fixed, a new ticket should be created, and will be done later. The unknown MIDI commands should be displayed as unknown, in a well formatted way.