### PR TITLE
Fixed reactivity for selectedElement

### DIFF
--- a/src/renderer/main/grid-layout/GridLayout.svelte
+++ b/src/renderer/main/grid-layout/GridLayout.svelte
@@ -431,7 +431,10 @@
         <div
           use:clickOutside={{ useCapture: true }}
           on:click-outside={() => {
-            if ($appSettings.modal == "") {
+            const selection =
+              Object.keys($selectedProfileStore).length !== 0 ||
+              Object.keys($selectedPresetStore).length !== 0;
+            if ($appSettings.modal == "" && selection) {
               selectedProfileStore.set({});
               selectedPresetStore.set({});
             }

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -10,13 +10,13 @@
   import ControlNameOverlay from "./overlays/ControlNameOverlay.svelte";
   import ProfileLoadOverlay from "./overlays/ProfileLoadOverlay.svelte";
   import PresetLoadOverlay from "./overlays/PresetLoadOverlay.svelte";
-  import { clickOutside } from "/main/_actions/click-outside.action";
 
   import { appSettings } from "../../../runtime/app-helper.store.js";
-  import { runtime, user_input } from "../../../runtime/runtime.store.js";
+  import { user_input } from "../../../runtime/runtime.store.js";
   import { selectedProfileStore } from "../../../runtime/profile-helper.store";
   import { selectedPresetStore } from "../../../runtime/preset-helper.store";
   import { isActionButtonClickedStore } from "/runtime/profile-helper.store";
+  import { get } from "svelte/store";
 
   const components = [
     { type: "BU16", component: BU16 },
@@ -45,25 +45,15 @@
   }
 
   $: {
-    const store = $selectedProfileStore;
-    if (store && !isActionButtonClicked) {
-      selectedElement = { id: "", brc: {}, event: {} };
-    }
-  }
-
-  $: {
-    const store = $selectedPresetStore;
-    if (store && !isActionButtonClicked) {
-      selectedElement = { id: "", brc: {}, event: {} };
-    }
-  }
-
-  $: {
-    if (
-      Object.keys($selectedProfileStore).length === 0 ||
-      Object.keys($selectedPresetStore).length === 0
-    ) {
-      selectedElement = $user_input;
+    if (!isActionButtonClicked) {
+      if (
+        Object.keys($selectedProfileStore).length !== 0 ||
+        Object.keys($selectedPresetStore).length !== 0
+      ) {
+        selectedElement = { id: "", brc: {}, event: {} };
+      } else {
+        selectedElement = $user_input;
+      }
     }
   }
 </script>


### PR DESCRIPTION
The reason for this issue was that at every time the user clicks on the grid layout, the selectedPreset and selectedProfile variables are reset. These are used for determining whether the selectedElement should be displayed, and since it was always reset, the selectedElement is always "reselected". 

The fix contains the checking for if there was already a preset or profile selection, only then the reactivity is triggered.