### PR TITLE
Fixed clipping and added text truncation for Action blocks

### DIFF
--- a/src/renderer/config-blocks/LedColor.svelte
+++ b/src/renderer/config-blocks/LedColor.svelte
@@ -514,7 +514,9 @@ A -> B : AB-First step
   <div class="w-full flex">
     {#each [scriptSegments[2], scriptSegments[3], scriptSegments[4]] as script, i}
       <div class={"w-1/3 atomicInput "}>
-        <div class="text-gray-500 text-sm pb-1">{parameterNames[i + 2]}</div>
+        <div class="text-gray-500 text-sm pb-1">
+          {parameterNames[i + 2]}
+        </div>
         <AtomicInput
           inputValue={script}
           validator={validators[i + 2]}

--- a/src/renderer/config-blocks/LedPhase.svelte
+++ b/src/renderer/config-blocks/LedPhase.svelte
@@ -137,7 +137,9 @@
   <div class="w-full flex">
     {#each scriptSegments as script, i}
       <div class={"w-1/" + scriptSegments.length + " atomicInput"}>
-        <div class="text-gray-500 text-sm pb-1">{parameterNames[i]}</div>
+        <div class="text-gray-500 text-sm pb-1 truncate">
+          {parameterNames[i]}
+        </div>
         <AtomicInput
           inputValue={script}
           suggestions={suggestions[i]}

--- a/src/renderer/config-blocks/Macro.svelte
+++ b/src/renderer/config-blocks/Macro.svelte
@@ -449,37 +449,35 @@
     visibleCaretPos = -1;
     caretPos = -1;
   }}
-  class="flex w-full flex-col items-start p-2"
+  class="flex w-full flex-col px-4 py-2 gap-2"
 >
-  <div class="flex flex-row w-full">
-    <div class="mr-auto text-gray-500 text-sm py-1 pl-2">Macro Input Field</div>
-    <div class="text-gray-500 text-sm py-1 pl-2 mr-2">Layout:</div>
-    <select
-      class="rounded bg-secondary text-white focus:outline-none border-select mr-2"
-      bind:value={selectedLayout}
-      on:change={change_layout}
-    >
-      {#each layouts as layout}
-        <option value={layout.name} class="text-white bg-secondary py-1"
-          >{layout.name}</option
-        >
-      {/each}
-    </select>
-  </div>
-  {#if $unsaved_changes}
-    <div class="pl-2 text-sm text-red-500">
-      Macros will take effect after storing
-    </div>
-  {/if}
+  <div class="flex flex-col">
+    <div class="flex flex-row justify-between mb-2">
+      <div class="text-gray-500 text-sm truncate">Macro Input Field</div>
 
-  <div class="flex w-full p-2">
+      <!-- Layout Selector -->
+      <div class="flex flex-row gap-2">
+        <div class="text-gray-500 text-sm">Layout:</div>
+        <select
+          class="rounded bg-secondary text-white focus:outline-none border-select"
+          bind:value={selectedLayout}
+          on:change={change_layout}
+        >
+          {#each layouts as layout}
+            <option value={layout.name} class="text-white bg-secondary py-1"
+              >{layout.name}</option
+            >
+          {/each}
+        </select>
+      </div>
+    </div>
+    <!-- Keyboard Input Field -->
     <div
       use:clickOutside={{ useCapture: true }}
-      id="idk"
       bind:this={macroInputField}
       class="{$unsaved_changes
-        ? 'focus:border-red-400 border-red-500'
-        : 'focus:border-select-desaturate-20 border-select'} editableDiv w-full rounded secondary border text-white p-2 flex flex-row flex-wrap focus:outline-none"
+        ? 'focus:border-error-desaturate-20 border-error'
+        : 'focus:border-select-desaturate-20 border-select'} editableDiv rounded secondary border text-white p-2 flex flex-row flex-wrap focus:outline-none"
       on:keydown|preventDefault={identifyKey}
       on:keyup|preventDefault={identifyKey}
       contenteditable="true"
@@ -500,84 +498,89 @@
         </div>
       {/each}
     </div>
-  </div>
-  <div class="flex flex-col w-full items-start p-2">
-    <div class="text-gray-500 text-sm pb-1">Add Key</div>
 
-    <div class="flex w-full items-start justify-between">
-      <div class="flex flex-col">
-        <select
-          bind:value={selectedKey}
-          class="bg-secondary flex flex-grow text-white p-1 focus:outline-none border-select"
-        >
-          {#each layout.lookup as key}
-            <option value={key} class="text-white bg-secondary py-1"
-              >{key.display}</option
-            >
-          {/each}
-        </select>
-        <div class="flex mt-1">
-          <div
-            on:click={() => {
-              addonKeyType = "keyup";
-            }}
-            class="{addonKeyType == 'keyup'
-              ? 'border-yellow-500 text-yellow-500'
-              : 'text-select-desaturate-20 border-select-desaturate-20'} px-2 m-0.5 text-sm bg-primary flex items-center border cursor-default rounded-md"
-          >
-            keyup
-          </div>
-          <div
-            on:click={() => {
-              addonKeyType = "keydown";
-            }}
-            class="{addonKeyType == 'keydown'
-              ? 'border-red-500 text-red-500'
-              : 'text-select-desaturate-20 border-select-desaturate-20'} px-2 m-0.5 text-sm bg-primary flex items-center border cursor-default rounded-md"
-          >
-            keydown
-          </div>
-          <div
-            on:click={() => {
-              addonKeyType = "keydownup";
-            }}
-            class="{addonKeyType == 'keydownup'
-              ? 'border-green-500 text-green-500'
-              : 'text-select-desaturate-20 border-select-desaturate-20'} px-2 m-0.5 text-sm bg-primary flex items-center border cursor-default rounded-md"
-          >
-            keydownup
-          </div>
-        </div>
-      </div>
-
-      <button
-        on:click={addKey}
-        class="flex items-center justify-center rounded border-2 border-commit bg-commit hover:bg-commit-saturate-20 text-white px-2"
-        >Add Key</button
-      >
+    <div class="text-sm text-error truncate" class:hidden={$unsaved_changes}>
+      Macros will take effect after storing
     </div>
   </div>
 
-  <div class="flex flex-col w-full items-start p-2">
-    <div class="text-gray-500 text-sm pb-1">Delay Key</div>
-    <div class="flex items-start justify-between w-full">
+  <div class="grid grid-cols-4 grid-rows-[auto_auto_auto] gap-x-2 gap-y-1">
+    <span class="text-gray-500 text-sm col-span-4">Add Key</span>
+    <select
+      bind:value={selectedKey}
+      class="text-white focus:outline-none border-select bg-primary flex col-span-3"
+    >
+      {#each layout.lookup as key}
+        <option value={key} class="text-white bg-secondary py-1"
+          >{key.display}</option
+        >
+      {/each}
+    </select>
+
+    <button
+      on:click={addKey}
+      class="text-center rounded bg-commit hover:bg-commit-saturate-20 text-white px-2 py-1 truncate"
+      >Add Key</button
+    >
+
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div
+      on:click={() => {
+        addonKeyType = "keyup";
+      }}
+      class="truncate text-sm text-center border rounded-md px-1
+          {addonKeyType == 'keyup'
+        ? 'border-yellow-500 text-yellow-500'
+        : 'text-select-desaturate-20 border-select-desaturate-20'} "
+    >
+      keyup
+    </div>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div
+      on:click={() => {
+        addonKeyType = "keydown";
+      }}
+      class="truncate text-sm text-center border rounded-md px-1
+          {addonKeyType == 'keydown'
+        ? 'border-red-500 text-red-500'
+        : 'text-select-desaturate-20 border-select-desaturate-20'}"
+    >
+      keydown
+    </div>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div
+      on:click={() => {
+        addonKeyType = "keydownup";
+      }}
+      class="truncate text-sm text-center border rounded-md px-1
+          {addonKeyType == 'keydownup'
+        ? 'border-green-500 text-green-500'
+        : 'text-select-desaturate-20 border-select-desaturate-20'}"
+    >
+      keydownup
+    </div>
+  </div>
+  <div class="flex flex-col">
+    <div class="text-gray-500 text-sm">Delay Key</div>
+    <div class="flex flex-row gap-2">
       <input
         bind:value={delayKey}
         type="number"
         min="5"
         max="4000"
-        class="bg-secondary flex flex-grow text-white py-1 px-2 focus:outline-none border-select"
+        class="bg-secondary flex flex-grow text-white focus:outline-none border-select px-2 py-1"
       />
       <button
         on:click={addDelay}
-        class="flex items-center justify-center rounded ml-2 border-2 border-commit bg-commit hover:bg-commit-saturate-20 text-white px-2"
-        >Add Delay</button
+        class="text-center rounded bg-commit hover:bg-commit-saturate-20 text-white px-2 py-1 truncate"
       >
+        Add Delay
+      </button>
     </div>
   </div>
+  <div class="flex flex-col">
+    <div class="text-gray-500 text-sm">Default Delay</div>
 
-  <div class="flex w-full flex-col p-2">
-    <div class="text-gray-500 text-sm pb-1">Default Delay</div>
     <input
       bind:value={defaultDelay}
       on:input={(e) => {
@@ -586,15 +589,16 @@
       type="number"
       min="5"
       max="4000"
-      class="bg-secondary w-full flex flex-grow text-white px-2 py-1 focus:outline-none border-select"
+      class="bg-secondary flex text-white focus:outline-none border-select px-2 py-1"
     />
   </div>
 
   <button
     on:click={clearMacro}
-    class="flex items-center justify-center rounded m-2 border-select bg-select border-2 hover:bg-red-500 text-white px-2 py-0.5"
-    >Clear All</button
+    class="text-center rounded bg-select hover:bg-red-500 text-white px-2 py-1 my-2"
   >
+    Clear All
+  </button>
 </div>
 
 <style>

--- a/src/renderer/config-blocks/Midi.svelte
+++ b/src/renderer/config-blocks/Midi.svelte
@@ -690,7 +690,8 @@
 <action-midi class="flex flex-col w-full p-2">
   {#if tabs !== undefined}
     <div class="ml-auto flex flex-row">
-      {#each tabs as element, i}
+      {#each tabs as element}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
           on:click={(e) => {
             dispatch("replace", element.component);
@@ -705,10 +706,12 @@
     </div>
   {/if}
 
-  <div class="w-full flex">
+  <div class="w-full grid grid-cols-{scriptSegments.length}">
     {#each scriptSegments as script, i}
-      <div class={"w-1/" + scriptSegments.length + " atomicInput"}>
-        <div class="text-gray-500 text-sm pb-1">{parameterNames[i]}</div>
+      <div class="flex flex-col atomicInput gap-1">
+        <div class="text-gray-500 text-sm truncate">
+          {parameterNames[i]}
+        </div>
         <AtomicInput
           inputValue={script}
           suggestions={suggestions[i]}

--- a/src/renderer/config-blocks/MidiFourteenBit.svelte
+++ b/src/renderer/config-blocks/MidiFourteenBit.svelte
@@ -696,14 +696,14 @@
 <action-midi class="flex flex-col w-full p-2">
   {#if tabs !== undefined}
     <div class="ml-auto flex flex-row">
-      {#each tabs as element, i}
+      {#each tabs as element}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
           on:click={(e) => {
             dispatch("replace", element.component);
           }}
-          class="tab {config.information.name == element.component
-            ? 'selected'
-            : ''}"
+          class="tab"
+          class:selected={config.information.name == element.component}
         >
           {element.name}
         </div>
@@ -711,10 +711,12 @@
     </div>
   {/if}
 
-  <div class="w-full flex">
+  <div class="w-full grid grid-cols-{scriptSegments.length}">
     {#each scriptSegments as script, i}
-      <div class={"w-1/" + scriptSegments.length + " atomicInput"}>
-        <div class="text-gray-500 text-sm pb-1">{parameterNames[i]}</div>
+      <div class="flex flex-col atomicInput gap-1">
+        <div class="text-gray-500 text-sm truncate">
+          {parameterNames[i]}
+        </div>
         <AtomicInput
           inputValue={script}
           suggestions={suggestions[i]}

--- a/src/renderer/config-blocks/SettingsEncoder.svelte
+++ b/src/renderer/config-blocks/SettingsEncoder.svelte
@@ -100,7 +100,7 @@
   <div class="w-full flex">
     <div class="w-1/2 flex flex-col">
       <div class="w-full px-2">
-        <div class="text-gray-500 text-sm pb-1">Encoder Mode</div>
+        <div class="text-gray-500 text-sm pb-1 truncate">Encoder Mode</div>
         <AtomicInput
           suggestions={suggestions[0]}
           validator={(e) => {
@@ -123,7 +123,7 @@
 
     <div class="w-1/2 flex flex-col">
       <div class="w-full px-2">
-        <div class="text-gray-500 text-sm pb-1">Encoder Velocity</div>
+        <div class="text-gray-500 text-sm pb-1 truncate">Encoder Velocity</div>
         <AtomicInput
           suggestions={suggestions[1]}
           validator={(e) => {

--- a/src/renderer/config-blocks/TimerStart.svelte
+++ b/src/renderer/config-blocks/TimerStart.svelte
@@ -101,7 +101,9 @@
   <div class="w-full flex">
     {#each scriptSegments as script, i}
       <div class={"w-1/" + scriptSegments.length + " atomicInput"}>
-        <div class="text-gray-500 text-sm pb-1">{parameterNames[i]}</div>
+        <div class="text-gray-500 text-sm pb-1 truncate">
+          {parameterNames[i]}
+        </div>
         <AtomicInput
           inputValue={script}
           suggestions={suggestions[i]}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -79,6 +79,10 @@ const config = {
         },
         error: {
           DEFAULT: "#DC2626",
+          "desaturate-10": "#DC4B4B",
+          "desaturate-20": "#DC7474",
+          "saturate-10": "#DC0F0F",
+          "saturate-20": "#FF0000",
         },
         pick: {
           DEFAULT: "#6B7AFF",


### PR DESCRIPTION
On smaller displays, some action blocks input field title is to long to be rendered in one line, causing the misalignment of the layout of these action blocks.

This fix contains the truncation of these titles, meaning when a title is too long, the title will be rendered in the following pattern: 
```
"Some Long Input Field Title" ⟶ "Some Long In...". 
```

The layout is intact on smaller displays.

A new issue was found during testing, this PR contains the fix for that too.
The issue is that the layout of some action blocks was coded poorly, and the automatic layout resizing had a implicitly defined minimum size. When the width of the Config menu was smaller than this minimum width of the action block, the action block "broke out" of the Config menu. See the following image:

![image](https://github.com/intechstudio/grid-editor/assets/37884778/a07af28c-7f6e-456a-8354-4ed224e21839)

The layout of MIDI MIDI14 and KeyboardMacro action blocks were reworked.


