### PR TITLE
Added fading in/out for Tracker when logger messages are displayed

### DIFF
--- a/src/renderer/main/grid-layout/GridLayout.svelte
+++ b/src/renderer/main/grid-layout/GridLayout.svelte
@@ -31,6 +31,7 @@
 
   import Pages from "/main/panels/configuration/components/Pages.svelte";
   import Tracker from "./Tracker.svelte";
+  import { logStreamStore } from "../user-interface/cursor-log/LogStream.store.js";
 
   const configuration = window.ctxProcess.configuration();
 
@@ -500,10 +501,12 @@
 
       <div class="w-full flex flex-col items-center min-h-fit mt-auto">
         <div class="w-full flex flex-row items-center min-h-fit mt-auto" />
-
+        <Tracker
+          visible={$logStreamStore.length === 0}
+          class="absolute bottom-0 right-0 mb-7 mr-10"
+        />
         <CursorLog />
       </div>
-      <Tracker class="absolute bottom-0 right-0 mb-7 mr-10" />
     </grid-layout>
   </div>
 </layout-container>

--- a/src/renderer/main/grid-layout/Tracker.svelte
+++ b/src/renderer/main/grid-layout/Tracker.svelte
@@ -2,9 +2,11 @@
   import { appSettings } from "../../runtime/app-helper.store";
   import mixpanel from "mixpanel-browser";
   import TooltipSetter from "../user-interface/tooltip/TooltipSetter.svelte";
+  import { fly } from "svelte/transition";
 
   let classProps;
   export { classProps as class };
+  export let visible = true;
 
   const options = [
     {
@@ -30,23 +32,27 @@
   }
 </script>
 
-<div
-  class="{classProps} flex flex-row gap-4 items-center bg-primary py-2 px-3 flex-wrap justify-center rounded-lg"
->
-  <span class="text-white">Interaction Tracking:</span>
-  <div class="flex flex-row gap-2 items-center">
-    {#each options as { value, label, tooltip_key }}
-      <button
-        class:selected={value === $appSettings.changeOnEvent}
-        on:click={() => handleClick(value)}
-        class="w-24 rounded bg-select text-white hover:bg-select-saturate-10 relative py-1"
-      >
-        <span>{label}</span>
-        <TooltipSetter key={tooltip_key} />
-      </button>
-    {/each}
+{#if visible}
+  <div
+    in:fly={{ x: -10, delay: 100 }}
+    out:fly={{ x: 10, delay: 0 }}
+    class="{classProps} flex flex-row gap-4 items-center bg-primary py-2 px-3 flex-wrap justify-center rounded-lg"
+  >
+    <span class="text-white">Interaction Tracking:</span>
+    <div class="flex flex-row gap-2 items-center">
+      {#each options as { value, label, tooltip_key }}
+        <button
+          class:selected={value === $appSettings.changeOnEvent}
+          on:click={() => handleClick(value)}
+          class="w-24 rounded bg-select text-white hover:bg-select-saturate-10 relative py-1"
+        >
+          <span>{label}</span>
+          <TooltipSetter key={tooltip_key} />
+        </button>
+      {/each}
+    </div>
   </div>
-</div>
+{/if}
 
 <style>
   button.selected {

--- a/src/renderer/main/user-interface/cursor-log/CursorLog.svelte
+++ b/src/renderer/main/user-interface/cursor-log/CursorLog.svelte
@@ -1,51 +1,11 @@
 <script>
   import { fly } from "svelte/transition";
-  import { logger } from "../../../runtime/runtime.store";
-
-  let logs = [];
-  let logClearTimeout = undefined;
-
-  $: {
-    if (typeof $logger !== "undefined") {
-      if (
-        logs.map((l) => l.classname).includes("pagechange") &&
-        $logger.classname == "strict"
-      ) {
-        logs = [];
-      }
-
-      clearTimeout(logClearTimeout);
-
-      const last = logs.at(-1);
-      if (
-        typeof last !== "undefined" &&
-        last.data.message === $logger.message
-      ) {
-        last.count++;
-      } else {
-        if (logs.length >= 6) {
-          logs.shift();
-        }
-        logs = [
-          ...logs,
-          {
-            data: $logger,
-            count: 1,
-          },
-        ];
-      }
-
-      logClearTimeout = setTimeout(() => {
-        logs = [];
-        logger.set(undefined);
-      }, 5000);
-    }
-  }
+  import { logStreamStore } from "./LogStream.store";
 </script>
 
 <div id="cursor-log" style="z-index:9999;" class="flex mx-auto">
   <div class="flex flex-col w-[30rem] px-4 py-1 text-white">
-    {#each logs as log, i}
+    {#each $logStreamStore as log, i}
       <div
         in:fly={{ x: -10, delay: 400 * i }}
         out:fly={{ x: 10, delay: 400 * i }}

--- a/src/renderer/main/user-interface/cursor-log/LogStream.store.js
+++ b/src/renderer/main/user-interface/cursor-log/LogStream.store.js
@@ -1,0 +1,49 @@
+import { writable, get } from "svelte/store";
+import { logger } from "../../../runtime/runtime.store";
+
+export let logStreamStore = createLogStream();
+
+let logClearTimeout = undefined;
+
+function createLogStream() {
+  const logStream = writable([]);
+
+  const unsubscribe = logger.subscribe((store) => {
+    const logs = get(logStream);
+    if (typeof store !== "undefined") {
+      if (
+        logs.map((l) => l.classname).includes("pagechange") &&
+        store.classname == "strict"
+      ) {
+        logStream.set([]);
+      }
+
+      clearTimeout(logClearTimeout);
+
+      const last = logs.at(-1);
+      if (typeof last !== "undefined" && last.data.message === store.message) {
+        last.count++;
+      } else {
+        if (logs.length >= 6) {
+          logs.shift();
+        }
+        logStream.update((store) => {
+          return [
+            ...logs,
+            {
+              data: get(logger),
+              count: 1,
+            },
+          ];
+        });
+      }
+
+      logClearTimeout = setTimeout(() => {
+        logStream.set([]);
+        logger.set(undefined);
+      }, 5000);
+    }
+  });
+
+  return logStream;
+}


### PR DESCRIPTION
- [x] When receiving a Logger message (on the bottom center of the screen, for example when trying to change pages during active changes), the visual display of these messages do not clash with the Tracking panel (OFF, Elements, Events bar on the bottom).
- [x] Works with multiple messages too
- [x] It should be displayed again, when all logger messages disappear
- [x] Has a cool animation, but it should be approved by QA