### PR TITLE
Fixed bug of changing to profile cloud when selecting preferences

### DIFF
--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -53,13 +53,10 @@
   $: {
     if (selected === "newLibrary") {
       $appSettings.profileBrowserMode = "newLibrary";
-      $appSettings.leftPanel = "NewProfile";
     } else if (selected === "legacyLibrary") {
       $appSettings.profileBrowserMode = "legacyLibrary";
-      $appSettings.leftPanel = "Profiles";
     } else if (selected == "profileCloud") {
       $appSettings.profileBrowserMode = "profileCloud";
-      $appSettings.leftPanel = "ProfileCloud";
     }
   }
 


### PR DESCRIPTION
- [ ] When selecting a different tab than Profile Cloud, and then switching to Preferences tab, the selection of the Preferences tab does not revert the selected left side tab to Profile Cloud