### PR TITLE
Always run in background exit crashed on macOS 

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -226,7 +226,6 @@ function createWindow() {
       mainWindow = null;
     } else {
       evt.preventDefault();
-
       // only hide, keep in the background
       const keepRunning = store.get("alwaysRunInTheBackground");
       if (keepRunning === true) {
@@ -501,6 +500,7 @@ ipcMain.handle("setPersistentStore", (event, arg) => {
   });
   return "saved";
 });
+
 // app window management
 ipcMain.handle("closeWindow", async (event, args) => {
   mainWindow.close();
@@ -586,11 +586,18 @@ ipcMain.on("restartApp", (event, arg) => {
 
 // Quit when all windows are closed.
 app.on("window-all-closed", (evt) => {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== "darwin") {
+  console.log("window-all-closed", app.quitting)
+  const keepRunning = store.get("alwaysRunInTheBackground");
+  if (keepRunning === true) {
+    // On macOS it is common for applications and their menu bar
+    // to stay active until the user quits explicitly with Cmd + Q
+    if (process.platform !== "darwin") {
+      app.quit();
+    }
+  } else {
     app.quit();
   }
+
 });
 
 app.on("activate", () => {
@@ -600,4 +607,7 @@ app.on("activate", () => {
 });
 
 // termination of application, closing the windows, used for macOS hide flag
-app.on("before-quit", () => (app.quitting = true));
+app.on("before-quit", () => {
+  (app.quitting = true)
+  console.log("before quit")
+});

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -586,7 +586,7 @@ ipcMain.on("restartApp", (event, arg) => {
 
 // Quit when all windows are closed.
 app.on("window-all-closed", (evt) => {
-  console.log("window-all-closed", app.quitting)
+  console.log("window-all-closed", app.quitting);
   const keepRunning = store.get("alwaysRunInTheBackground");
   if (keepRunning === true) {
     // On macOS it is common for applications and their menu bar
@@ -597,7 +597,6 @@ app.on("window-all-closed", (evt) => {
   } else {
     app.quit();
   }
-
 });
 
 app.on("activate", () => {
@@ -608,6 +607,6 @@ app.on("activate", () => {
 
 // termination of application, closing the windows, used for macOS hide flag
 app.on("before-quit", () => {
-  (app.quitting = true)
-  console.log("before quit")
+  app.quitting = true;
+  console.log("before quit");
 });


### PR DESCRIPTION
#322 
When always run in the background was ticked OFF, closing the app resulted in crash. Fixed by adding logic to "window-all-closed" under darwin.

App should stay on tray under linux/windows and stay on dock on macos, when running in the background is active. When inactive, quit the app for good. Default behaviour should be on?

- [x] Test on Windows
- [x] Test on Linux
- [x] Test on MacOS