### PR TITLE
KKERTI removed unused props from config loading

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -709,10 +709,8 @@
                 <div class="flex flex-row justify-between">
                   <DynamicWrapper
                     let:toggle
-                    drag_start={isDragged}
                     {index}
                     {config}
-                    configs={$configs}
                     {access_tree}
                     indentation={config.indentation}
                     on:update={handleConfigUpdate}
@@ -731,7 +729,6 @@
                   <AddAction
                     on:paste={handlePaste}
                     {animation}
-                    {config}
                     configs={$configs}
                     {index}
                     on:new-config={handleConfigInsertion}


### PR DESCRIPTION
The console was full of warnings about unused props. To ease debugging, I have removed the most prominent ones. The exported properties were not used anymore after multiple rafactor.