### PR TITLE
Fixed orientation and selection for profile and preset overlay

### DIFF
--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -21,6 +21,7 @@
   import { isActionButtonClickedStore } from "/runtime/profile-helper.store";
   import { get } from "svelte/store";
   import { writeBuffer } from "../../../runtime/engine.store.js";
+  import { runtime } from "../../../runtime/runtime.store.js";
 
   const components = [
     { type: "BU16", component: BU16 },
@@ -70,6 +71,25 @@
       } else {
         selectedElement = $user_input;
       }
+    }
+  }
+
+  let showProfileLoadOverlay = false;
+  $: {
+    showProfileLoadOverlay = type === $selectedProfileStore.type;
+    console.log($selectedProfileStore, showProfileLoadOverlay);
+  }
+
+  let showPresetLoadOverlay = false;
+  $: {
+    let device = get(runtime).find((controller) => controller.id == id);
+
+    if (typeof device !== "undefined") {
+      const compatible = device.pages[0].control_elements
+        .map((e) => e.controlElementType)
+        .includes($selectedPresetStore.type);
+
+      showPresetLoadOverlay = compatible;
     }
   }
 </script>
@@ -137,8 +157,12 @@
     {/if}
 
     {#if $writeBuffer.length == 0}
-      <ProfileLoadOverlay {id} />
-      <PresetLoadOverlay {id} {rotation} bankActive={0} {moduleWidth} />
+      {#if showProfileLoadOverlay && $appSettings.leftPanel === "ProfileCloud"}
+        <ProfileLoadOverlay {id} {rotation} />
+      {/if}
+      {#if showPresetLoadOverlay && $appSettings.leftPanel === "NewPreset"}
+        <PresetLoadOverlay {id} {rotation} bankActive={0} {moduleWidth} />
+      {/if}
     {/if}
   </svelte:component>
 {/if}

--- a/src/renderer/main/grid-layout/grid-modules/event-handlers/select.js
+++ b/src/renderer/main/grid-layout/grid-modules/event-handlers/select.js
@@ -8,10 +8,6 @@ export function selectElement(controlNumber, controlElementType, moduleId) {
     const dx = moduleId.split(";")[0].split(":").pop();
     const dy = moduleId.split(";")[1].split(":").pop();
 
-    //reset of profile selecting
-    selectedProfileStore.set({});
-    selectedPresetStore.set({});
-
     // this should be checked to not reupdate UI when clicking on a control element.
     // should be probably put into user_input store's functions
     const ui = get(user_input);

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -1,23 +1,18 @@
 <script>
   import { selectedPresetStore } from "../../../../runtime/preset-helper.store";
-  import {
-    elementNameStore,
-    runtime,
-    user_input,
-  } from "../../../../runtime/runtime.store";
+  import { runtime, user_input } from "../../../../runtime/runtime.store";
 
   import { get } from "svelte/store";
   import { selectedControllerIndexStore } from "/runtime/preset-helper.store";
 
   import { Analytics } from "../../../../runtime/analytics.js";
 
+  import { appSettings } from "../../../../runtime/app-helper.store";
+
   export let id;
   export let moduleWidth;
 
   export let rotation;
-
-  let showOverlay = false;
-  let selectedPreset;
 
   let overlayDesign;
   let controlElementSettings;
@@ -32,36 +27,6 @@
     }
   }
 
-  let isModuleCompatibleWithPreset = false;
-
-  function showLoadPresetOverlay() {
-    isModuleCompatibleWithPreset = false;
-
-    let device;
-    device = get(runtime).find((controller) => controller.id == id);
-
-    if (typeof device === "undefined") {
-      return;
-    }
-
-    device.pages[0].control_elements.forEach((element) => {
-      if (element.controlElementType == selectedPreset.type) {
-        isModuleCompatibleWithPreset = true;
-      }
-    });
-
-    if (isModuleCompatibleWithPreset === true) {
-      showOverlay = true;
-    } else {
-      showOverlay = false;
-    }
-  }
-
-  $: {
-    selectedPreset = $selectedPresetStore;
-    showLoadPresetOverlay();
-  }
-
   $: if (id) {
     if (id.startsWith("PBF4")) {
       overlayDesign = "3x4";
@@ -71,16 +36,6 @@
       overlayDesign = "4x4";
     }
   }
-
-  $: breakpoint = moduleWidth > 200 ? "large" : "small";
-
-  const control_block = (number) => {
-    let array = [];
-    for (let i = 0; i < number; i++) {
-      array.push(i);
-    }
-    return array;
-  };
 
   function selectModuleWhereProfileIsLoaded(element) {
     const dx = id.split(";")[0].split(":").pop();
@@ -104,8 +59,8 @@
       mandatory: false,
     });
 
-    if (selectedPreset !== undefined) {
-      const preset = selectedPreset;
+    if ($selectedPresetStore !== undefined) {
+      const preset = $selectedPresetStore;
 
       const rt = get(runtime);
       const ui = get(user_input);
@@ -132,59 +87,59 @@
   }
 </script>
 
-{#if showOverlay}
-  {#if "system" == selectedPreset.type}
-    <div
-      class=" overlay text-white w-full h-full justify-items-center items-end gap-1"
-    >
-      <button
-        on:click={() => {
-          loadPreset(controlElementSettings[controlElementSettings.length - 1]);
-        }}
-        class="group bg-gray-300 hover:bg-commit-saturate-20
-opacity-80 block h-full
-w-full text-white bg-opacity-25 rounded
-focus:outline-none"
-        ><div
-          style="transform: rotate({1 * rotation * 90 + 'deg'}"
-          class="hidden group-hover:block"
-        >
-          Load
-        </div>
-      </button>
-    </div>
-  {:else}
-    <div
-      class=" overlay text-white w-full h-full justify-items-center items-end gap-1 grid-cols-4 grid-rows-4 {overlayDesign ==
-      '3x4'
-        ? 'pbf4'
-        : overlayDesign == '2x4'
-        ? 'ef44'
-        : ''} grid"
-    >
-      {#each controlElementSettings.slice(0, -1) as element}
-        <div class="h-full w-full">
-          {#if element.controlElementType == selectedPreset.type}
-            <button
-              on:click={() => {
-                loadPreset(element);
-              }}
-              class="group bg-gray-300 hover:bg-commit-saturate-20
+{#if "system" == $selectedPresetStore.type}
+  <div
+    class=" overlay text-white w-full h-full justify-items-center items-end gap-1"
+  >
+    <button
+      on:click={() => {
+        loadPreset(controlElementSettings[controlElementSettings.length - 1]);
+      }}
+      class="group bg-gray-300 hover:bg-commit hover:bg-opacity-100
+block h-full w-full text-white bg-opacity-25 rounded focus:outline-none"
+      ><div
+        style="transform: rotate({rotation * 90 -
+          $appSettings.persistant.moduleRotation +
+          'deg'})"
+        class="hidden group-hover:block"
+      >
+        Load
+      </div>
+    </button>
+  </div>
+{:else}
+  <div
+    class=" overlay text-white w-full h-full justify-items-center items-end gap-1 grid-cols-4 grid-rows-4 {overlayDesign ==
+    '3x4'
+      ? 'pbf4'
+      : overlayDesign == '2x4'
+      ? 'ef44'
+      : ''} grid"
+  >
+    {#each controlElementSettings.slice(0, -1) as element}
+      <div class="h-full w-full">
+        {#if element.controlElementType == $selectedPresetStore.type}
+          <button
+            on:click={() => {
+              loadPreset(element);
+            }}
+            class="group bg-gray-300 hover:bg-commit-saturate-20
         opacity-80 block h-full
     w-full text-white bg-opacity-25 rounded
      focus:outline-none"
-              ><div
-                style="transform: rotate({1 * rotation * 90 + 'deg'}"
-                class="hidden group-hover:block"
-              >
-                Load
-              </div>
-            </button>
-          {/if}
-        </div>
-      {/each}
-    </div>
-  {/if}
+            ><div
+              style="transform: rotate({rotation * 90 -
+                $appSettings.persistant.moduleRotation +
+                'deg'})"
+              class="hidden group-hover:block"
+            >
+              Load
+            </div>
+          </button>
+        {/if}
+      </div>
+    {/each}
+  </div>
 {/if}
 
 <style>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -1,32 +1,15 @@
 <script>
   import { selectedProfileStore } from "../../../../runtime/profile-helper.store";
   import { runtime, user_input } from "../../../../runtime/runtime.store";
-  import { isActionButtonClickedStore } from "/runtime/profile-helper.store";
   import { appSettings } from "/runtime/app-helper.store";
   import { Analytics } from "../../../../runtime/analytics.js";
   export let id;
+  export let rotation;
 
-  let showOverlay = false;
   let selectedProfile = undefined;
-  let isActionButtonClicked = false;
 
   $: {
     selectedProfile = $selectedProfileStore;
-    showLoadProfileOverlay(id, $selectedProfileStore.type);
-  }
-
-  $: {
-    isActionButtonClicked = $isActionButtonClickedStore;
-    showLoadProfileOverlay(id, $isActionButtonClickedStore.type);
-  }
-
-  function showLoadProfileOverlay(moduleId, profileType) {
-    let moduleType = moduleId.substr(0, 4);
-    if (moduleType == profileType && isActionButtonClicked == false) {
-      showOverlay = true;
-    } else {
-      showOverlay = false;
-    }
   }
 
   function selectModuleWhereProfileIsLoaded() {
@@ -64,34 +47,34 @@
   }
 </script>
 
-{#if showOverlay}
-  <div
-    class="text-white bg-black bg-opacity-30 z-[1] w-full flex flex-col
+<div
+  class="text-white bg-black bg-opacity-30 z-[1] w-full flex flex-col
     items-center justify-center rounded h-full absolute"
-    style="transform: rotate({$appSettings.persistant.moduleRotation + 'deg'})"
-  >
-    <div class="w-fit relative">
-      <button
-        on:click={() => {
-          loadProfileToThisModule();
-        }}
-        class="px-4 py-2 rounded bg-commit hover:bg-commit-saturate-20
+  style="transform: rotate({rotation * 90 -
+    $appSettings.persistant.moduleRotation +
+    'deg'})"
+>
+  <div class="w-fit relative">
+    <button
+      on:click={() => {
+        loadProfileToThisModule();
+      }}
+      class="px-4 py-2 rounded bg-commit hover:bg-commit-saturate-20
         opacity-80 block"
-      >
-        Load Profile
-      </button>
-    </div>
-
-    <div class="w-fit">
-      <button
-        class="bg-select px-4 py-1 rounded hover:bg-select-saturate-20
-        left-[37%] absolute bottom-[22%] opacity-60"
-        on:click={() => {
-          cancelProfileOverlay();
-        }}
-      >
-        Cancel
-      </button>
-    </div>
+    >
+      Load Profile
+    </button>
   </div>
-{/if}
+
+  <div class="w-fit">
+    <button
+      class="bg-select px-4 py-1 rounded hover:bg-select-saturate-20
+        left-[37%] absolute bottom-[22%] opacity-60"
+      on:click={() => {
+        cancelProfileOverlay();
+      }}
+    >
+      Cancel
+    </button>
+  </div>
+</div>

--- a/src/renderer/main/panels/newPreset/NewPreset.svelte
+++ b/src/renderer/main/panels/newPreset/NewPreset.svelte
@@ -4,7 +4,7 @@
   import { selectedPresetStore } from "/runtime/preset-helper.store";
   import { isActionButtonClickedStore } from "/runtime/profile-helper.store";
   import { presetChangeCallbackStore } from "./preset-change.store";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { v4 as uuidv4 } from "uuid";
   import { Pane, Splitpanes } from "svelte-splitpanes";
   import {
@@ -646,6 +646,10 @@
     animateFade = true;
     animateFly = false;
     moveOld();
+  });
+
+  onDestroy(() => {
+    selectedPresetStore.set({});
   });
 </script>
 

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -569,6 +569,7 @@
     console.log("De-initialize Profile Cloud");
     window.removeEventListener("message", initChannelCommunication);
     window.electron.stopOfflineProfileCloud();
+    selectedProfileStore.set({});
   });
 
   async function loadOfflineProfileCloud() {

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -277,10 +277,6 @@ function create_user_input() {
         return;
       }
 
-      //reset of profile selecting
-      selectedProfileStore.set({});
-      selectedPresetStore.set({});
-
       _event.update((store) => {
         const rt = get(runtime);
 


### PR DESCRIPTION
When a module is connected it is rotated by the:

1. orientation of the connected module (by connecting the module in a 90/180/270 degree relative to the main module)
2. global orientation that is set in the preferences

These two rotation types are combined for the calculation of the main view in the editor.

The bug was that the preset/profile load overlay was rotated with the modules.

Test for:

- Different module connection rotations
- Different global rotation in preferences
- With combinations

In every combination the preset/profile overlay should be consistent and facing upwards (readable with text).