### PR TITLE
Toggle elements now opened after event changes

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -47,7 +47,7 @@
   import { selectedControllerIndexStore } from "/runtime/preset-helper.store";
 
   const configs = writable([]);
-  let lastOpenedElementsType = undefined;
+  let lastOpenedElementsType = [];
   let events = { options: ["", "", ""], selected: "" };
   let elements = { options: [], selected: "" };
 
@@ -547,7 +547,7 @@
     }
 
     for (const config of $configs) {
-      if (config.short === lastOpenedElementsType) {
+      if (lastOpenedElementsType.includes(config.short)) {
         config.toggled = true;
       }
     }
@@ -609,7 +609,11 @@
     const { value, index } = e.detail;
 
     if (value) {
-      lastOpenedElementsType = $configs[index].short;
+      lastOpenedElementsType.push($configs[index].short);
+    } else {
+      lastOpenedElementsType = lastOpenedElementsType.filter(
+        (e) => e !== $configs[index].short
+      );
     }
   }
 </script>


### PR DESCRIPTION
Now not only the lastly toggled action block is auto-toggled when changing an event, but all the blocks that were opened on the previous event, if possible.

Mind that, when on event #1 a (for example) code block was opened, changing first to event #2 (where no code blocks are present) nothing will open. But when changing to event #3 (where a code block is present) the code block is toggled, even though on event #2 no code blocks were interacted with.

This behaviour can lead to confusing situations, but the solution is consistent with the requirement of all toggled action blocks should be auto-toggled when changing events.

Further discussions of functional behaviour could be necessary, if QA or PO initiates it.