### PR TITLE
Added unsaved changes overlay

### DIFF
--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -229,6 +229,11 @@
     border-radius: 0.5rem;
   }
 
+  .unsaved-changes {
+    border: 1px dotted #0ba484 !important;
+    border-radius: 0.5rem;
+  }
+
   .active-systemelement {
     background-color: #212a2b;
     box-shadow: inset 0 0 10px #dddddd60;

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -229,11 +229,6 @@
     border-radius: 0.5rem;
   }
 
-  .unsaved-changes {
-    background-color: theme("colors.unsavedchange.DEFAULT") !important;
-    border-radius: 0.5rem;
-  }
-
   .active-systemelement {
     background-color: #212a2b;
     box-shadow: inset 0 0 10px #dddddd60;

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -230,7 +230,7 @@
   }
 
   .unsaved-changes {
-    border: 1px dotted #0ba484 !important;
+    background-color: theme("colors.unsavedchange.DEFAULT") !important;
     border-radius: 0.5rem;
   }
 

--- a/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
@@ -7,7 +7,10 @@
   import Led from "../elements/Led.svelte";
 
   import { elementPositionStore } from "../../../../runtime/runtime.store";
-  import { ledColorStore } from "../../../../runtime/runtime.store";
+  import {
+    unsaved_changes,
+    ledColorStore,
+  } from "../../../../runtime/runtime.store";
 
   export let moduleWidth;
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -97,7 +100,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
@@ -92,10 +92,12 @@
     >
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/BU16.svelte
@@ -96,31 +96,37 @@
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "button",
-              id: id,
-            });
-            elementNumber;
-          }}
-        >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Button
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+        <cell class="w-full h-full flex items-center justify-center relative">
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "button",
+                id: id,
+              });
+              elementNumber;
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Button
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
@@ -93,10 +93,12 @@
     >
       {#each [0, 1, 2, 3] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {
@@ -118,10 +120,12 @@
 
       {#each [4, 5, 6, 7] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-3"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
@@ -97,61 +97,77 @@
       {#each [0, 1, 2, 3] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-1"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "encoder",
-              id: id,
-            });
-          }}
+        <cell
+          class="w-full h-full flex items-center justify-center relative row-span-1"
         >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Encoder
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "encoder",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Encoder
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
 
       {#each [4, 5, 6, 7] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-3"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "fader",
-              id: id,
-            });
-          }}
+        <cell
+          class="w-full h-full flex items-center justify-center relative row-span-3"
         >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Fader
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
-            rotation={rotation * -90}
-            faderHeight={68}
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "fader",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Fader
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+              rotation={rotation * -90}
+              faderHeight={68}
+            />
+          </div>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EF44.svelte
@@ -8,7 +8,10 @@
   import Led from "../elements/Led.svelte";
 
   import { elementPositionStore } from "../../../../runtime/runtime.store";
-  import { ledColorStore } from "../../../../runtime/runtime.store";
+  import {
+    unsaved_changes,
+    ledColorStore,
+  } from "../../../../runtime/runtime.store";
 
   export let moduleWidth;
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -98,7 +101,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {
@@ -125,7 +130,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-3"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
@@ -25,8 +25,6 @@
 
   let dx, dy;
 
-  $: console.log($user_input);
-
   let elementposition_array = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
   let ledcolor_array = [
     [0, 0, 0],

--- a/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
@@ -100,30 +100,36 @@
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "encoder",
-              id: id,
-            });
-          }}
-        >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Encoder
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+        <cell class="w-full h-full flex items-center justify-center relative">
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "encoder",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Encoder
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
@@ -6,8 +6,15 @@
   import Encoder from "../elements/Encoder.svelte";
   import Led from "../elements/Led.svelte";
 
-  import { elementPositionStore } from "../../../../runtime/runtime.store";
+  import {
+    elementPositionStore,
+    eventType,
+  } from "../../../../runtime/runtime.store";
   import { ledColorStore } from "../../../../runtime/runtime.store";
+  import {
+    unsaved_changes,
+    user_input,
+  } from "../../../../runtime/runtime.store";
 
   export let moduleWidth;
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -17,6 +24,8 @@
   const dispatch = createEventDispatcher();
 
   let dx, dy;
+
+  $: console.log($user_input);
 
   let elementposition_array = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
   let ledcolor_array = [
@@ -92,10 +101,14 @@
     >
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/EN16.svelte
@@ -102,7 +102,7 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <cell class="w-full h-full flex items-center justify-center relative">
           <unsaved-changes-underlay
-            class="bg-white absolute rounded-lg bg-opacity-10"
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
             class:hidden={typeof $unsaved_changes.find(
               (e) => e.x == dx && e.y == dy && e.element == elementNumber
             ) === "undefined"}

--- a/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
@@ -94,90 +94,112 @@
     >
       {#each [0, 1, 2, 3] as elementNumber}
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-1"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "potentiometer",
-              id: id,
-            });
-          }}
-        >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Potentiometer
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+        <cell class="w-full h-full flex items-center justify-center relative">
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1] row-span-1"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "potentiometer",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Potentiometer
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
 
       {#each [4, 5, 6, 7] as elementNumber}
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-2"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "fader",
-              id: id,
-            });
-          }}
+        <cell
+          class="w-full h-full flex items-center justify-center relative row-span-2"
         >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-
-          <Fader
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
-            rotation={rotation * -90}
-            faderHeight={37}
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "fader",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+
+            <Fader
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+              rotation={rotation * -90}
+              faderHeight={37}
+            />
+          </div>
+        </cell>
       {/each}
 
       {#each [8, 9, 10, 11] as elementNumber}
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-1"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "button",
-              id: id,
-            });
-          }}
+        <cell
+          class="w-full h-full flex items-center justify-center relative row-span-1"
         >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-
-          <Button
-            {id}
-            position={elementposition_array[elementNumber]}
-            {elementNumber}
-            size={2.1}
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "button",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+
+            <Button
+              {id}
+              position={elementposition_array[elementNumber]}
+              {elementNumber}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
@@ -90,10 +90,12 @@
       class="grid grid-cols-4 grid-rows-4 h-full w-full justify-items-center items-center"
     >
       {#each [0, 1, 2, 3] as elementNumber}
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {
@@ -114,10 +116,12 @@
       {/each}
 
       {#each [4, 5, 6, 7] as elementNumber}
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-2"
           on:click={() => {
             dispatch("click", {
@@ -141,10 +145,12 @@
       {/each}
 
       {#each [8, 9, 10, 11] as elementNumber}
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PBF4.svelte
@@ -9,7 +9,10 @@
   import Button from "../elements/Button.svelte";
 
   import { elementPositionStore } from "../../../../runtime/runtime.store";
-  import { ledColorStore } from "../../../../runtime/runtime.store";
+  import {
+    unsaved_changes,
+    ledColorStore,
+  } from "../../../../runtime/runtime.store";
 
   export let id = "PBF4";
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -95,7 +98,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {
@@ -121,7 +126,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-2"
           on:click={() => {
             dispatch("click", {
@@ -150,7 +157,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-1"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
@@ -92,10 +92,12 @@
     >
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
@@ -96,30 +96,36 @@
       {#each [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led"
-          on:click={() => {
-            dispatch("click", {
-              elementNumber: elementNumber,
-              type: "potentiometer",
-              id: id,
-            });
-          }}
-        >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Potentiometer
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+        <cell class="w-full h-full flex items-center justify-center relative">
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </div>
+          <div
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => {
+              dispatch("click", {
+                elementNumber: elementNumber,
+                type: "potentiometer",
+                id: id,
+              });
+            }}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Potentiometer
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </div>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/PO16.svelte
@@ -7,7 +7,10 @@
   import Led from "../elements/Led.svelte";
 
   import { elementPositionStore } from "../../../../runtime/runtime.store";
-  import { ledColorStore } from "../../../../runtime/runtime.store";
+  import {
+    unsaved_changes,
+    ledColorStore,
+  } from "../../../../runtime/runtime.store";
 
   export let id = "PO16";
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -97,7 +100,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led"
           on:click={() => {
             dispatch("click", {

--- a/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
@@ -100,6 +100,7 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led row-span-2 col-span-2 relative"
           style="border-radius: 50%; padding: 6px"
           on:click={() => selectElement(elementNumber, "encoder", id)}
@@ -138,6 +139,7 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
+          class:unsaved-changes={true}
           class="knob-and-led"
           on:click={() => selectElement(elementNumber, "button", id)}
         >

--- a/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
@@ -10,7 +10,10 @@
   import Led from "../elements/Led.svelte";
 
   import { elementPositionStore } from "../../../../runtime/runtime.store.js";
-  import { ledColorStore } from "../../../../runtime/runtime.store.js";
+  import {
+    unsaved_changes,
+    ledColorStore,
+  } from "../../../../runtime/runtime.store.js";
 
   export let moduleWidth;
   export let selectedElement = { id: "", brc: {}, event: {} };
@@ -100,7 +103,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led row-span-2 col-span-2 relative"
           style="border-radius: 50%; padding: 6px"
           on:click={() => selectElement(elementNumber, "encoder", id)}
@@ -139,7 +144,9 @@
           class:active-element={dx == selectedElement.brc.dx &&
             dy == selectedElement.brc.dy &&
             selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={true}
+          class:unsaved-changes={typeof $unsaved_changes.find(
+            (e) => e.x == dx && e.y == dy && e.element == elementNumber
+          ) !== "undefined"}
           class="knob-and-led"
           on:click={() => selectElement(elementNumber, "button", id)}
         >

--- a/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/TEK2.svelte
@@ -98,66 +98,80 @@
     >
       {#each [8, 9] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <button
-          ariarole="button"
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led row-span-2 col-span-2 relative"
-          style="border-radius: 50%; padding: 6px"
-          on:click={() => selectElement(elementNumber, "encoder", id)}
+        <cell
+          class="w-full h-full flex items-center justify-center relative col-span-2 row-span-2"
         >
-          {#each [0, 1, 2, 3, 4] as ledNumber}
-            <div
-              class="absolute"
-              style="
-                margin-left: {ledPosRadius *
-                Math.cos(((25 + ledNumber * 10) / 180) * Math.PI)}px; 
-                margin-top: {ledPosRadius *
-                Math.sin(((25 + ledNumber * 10) / 180) * Math.PI)}px; 
-              "
-            >
-              <Led
-                color={ledcolor_array[
-                  (elementNumber == 8 ? 8 : 9) + ledNumber * 2
-                ]}
-                size={1.4}
-              />
-            </div>
-          {/each}
-
-          <EndlessPot
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </button>
+          <button
+            ariarole="button"
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led relative z-[2]"
+            style="border-radius: 50%; padding: 6px"
+            on:click={() => selectElement(elementNumber, "encoder", id)}
+          >
+            {#each [0, 1, 2, 3, 4] as ledNumber}
+              <div
+                class="absolute"
+                style="
+                margin-left: {ledPosRadius *
+                  Math.cos(((25 + ledNumber * 10) / 180) * Math.PI)}px; 
+                margin-top: {ledPosRadius *
+                  Math.sin(((25 + ledNumber * 10) / 180) * Math.PI)}px; 
+              "
+              >
+                <Led
+                  color={ledcolor_array[
+                    (elementNumber == 8 ? 8 : 9) + ledNumber * 2
+                  ]}
+                  size={1.4}
+                />
+              </div>
+            {/each}
+
+            <EndlessPot
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </button>
+        </cell>
       {/each}
 
       {#each [0, 1, 2, 3, 4, 5, 6, 7] as elementNumber}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <button
-          class:active-element={dx == selectedElement.brc.dx &&
-            dy == selectedElement.brc.dy &&
-            selectedElement.event.elementnumber == elementNumber}
-          class:unsaved-changes={typeof $unsaved_changes.find(
-            (e) => e.x == dx && e.y == dy && e.element == elementNumber
-          ) !== "undefined"}
-          class="knob-and-led"
-          on:click={() => selectElement(elementNumber, "button", id)}
-        >
-          <Led color={ledcolor_array[elementNumber]} size={2.1} />
-          <Button
-            {elementNumber}
-            {id}
-            position={elementposition_array[elementNumber]}
-            size={2.1}
+        <cell class="w-full h-full flex items-center justify-center relative">
+          <unsaved-changes-underlay
+            class="bg-white absolute rounded-lg bg-opacity-10 z-[1]"
+            class:hidden={typeof $unsaved_changes.find(
+              (e) => e.x == dx && e.y == dy && e.element == elementNumber
+            ) === "undefined"}
+            style="width: calc(100% - 5px); height: calc(100% - 5px)"
           />
-        </button>
+          <button
+            class:active-element={dx == selectedElement.brc.dx &&
+              dy == selectedElement.brc.dy &&
+              selectedElement.event.elementnumber == elementNumber}
+            class="knob-and-led z-[2]"
+            on:click={() => selectElement(elementNumber, "button", id)}
+          >
+            <Led color={ledcolor_array[elementNumber]} size={2.1} />
+            <Button
+              {elementNumber}
+              {id}
+              position={elementposition_array[elementNumber]}
+              size={2.1}
+            />
+          </button>
+        </cell>
       {/each}
     </div>
   </div>

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -508,8 +508,8 @@
           handleChangeEventTab("uiEvents");
         }}
         class="{!isSystemEventSelected
-          ? 'shadow-md bg-pick text-white'
-          : 'hover:bg-pick-desaturate-10 text-gray-50 bg-secondary'} relative m-2 p-1 flex-grow border-0 rounded focus:outline-none w-48"
+          ? 'shadow-md text-white bg-secondary-brightness-20'
+                : 'hover:bg-secondary-brightness-10 text-gray-50 bg-secondary'} relative m-2 p-1 flex-grow border-0 rounded focus:outline-none w-48"
       >
         <span> UI Events </span>
       </button>
@@ -524,8 +524,8 @@
           handleChangeEventTab("systemEvents");
         }}
         class="{isSystemEventSelected
-          ? 'shadow-md bg-pick text-white'
-          : 'hover:bg-pick-desaturate-10 text-gray-50 bg-secondary '} relative m-2 p-1 flex-grow border-0 rounded focus:outline-none w-48"
+          ? 'shadow-md text-white bg-secondary-brightness-20'
+                : 'hover:bg-secondary-brightness-10 text-gray-50 bg-secondary'} relative m-2 p-1 flex-grow border-0 rounded focus:outline-none w-48"
       >
         <span> System Events </span>
       </button>

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -4,6 +4,7 @@
   import {
     elementNameStore,
     user_input,
+    unsaved_changes,
   } from "../../../runtime/runtime.store.js";
 
   import { setTooltip } from "../../user-interface/tooltip/Tooltip.js";
@@ -15,10 +16,22 @@
   const dispatch = createEventDispatcher();
 
   class Event {
-    constructor({ label = "", value = null, selected = false }) {
+    constructor({
+      label = "",
+      value = null,
+      selected = false,
+      dx,
+      dy,
+      element,
+      page,
+    }) {
       this.label = label;
       this.value = value;
       this.selected = selected;
+      this.dx = dx;
+      this.dy = dy;
+      this.element = element;
+      this.page = page;
     }
   }
 
@@ -52,8 +65,15 @@
         label: String(e.event.desc),
         value: Number(e.event.value),
         selected: target.eventType == e.event.value,
+        dx: target.device.dx,
+        dy: target.device.dy,
+        element: target.element,
+        page: target.page,
       });
     });
+
+    console.log(events);
+    console.log($unsaved_changes);
 
     selectedElement = target.element;
   }
@@ -151,6 +171,15 @@
       <div class="flex w-full">
         {#if events.length > 0}
           {#each events as event}
+            {@const isChange =
+              typeof $unsaved_changes.find(
+                (e) =>
+                  e.x == event.dx &&
+                  e.y == event.dy &&
+                  e.element == event.element &&
+                  e.event == event.value
+              ) !== "undefined"}
+
             <button
               use:setTooltip={{
                 key: `event_${event.label}`,
@@ -162,12 +191,18 @@
               }}
               class="{event.selected
                 ? 'shadow-md text-white bg-pick'
-                : 'hover:bg-pick-desaturate-10 text-gray-50 bg-secondary'} relative m-2 first:ml-0 last:mr-0 p-1 flex-grow border-0 rounded focus:outline-none"
+                : 'hover:bg-pick-desaturate-10 text-gray-50 bg-secondary'} relative m-2 first:ml-0
+                last:mr-0 p-1 flex-grow border-0 rounded focus:outline-none"
             >
               <span
                 >{event.label.charAt(0).toUpperCase() +
                   event.label.slice(1)}</span
               >
+              {#if isChange}
+                <unsaved-changes-marker
+                  class="absolute right-0 top-0 w-4 h-4 bg-unsavedchange rounded-full translate-x-1/2 -translate-y-1/2"
+                />
+              {/if}
             </button>
           {/each}
         {:else}

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -190,8 +190,8 @@
                 handleSelectEvent(event);
               }}
               class="{event.selected
-                ? 'shadow-md text-white bg-pick'
-                : 'hover:bg-pick-desaturate-10 text-gray-50 bg-secondary'} relative m-2 first:ml-0
+                ? 'shadow-md text-white bg-secondary-brightness-20'
+                : 'hover:bg-secondary-brightness-10 text-gray-50 bg-secondary'} relative m-2 first:ml-0
                 last:mr-0 p-1 flex-grow border-0 rounded focus:outline-none"
             >
               <span
@@ -200,7 +200,7 @@
               >
               {#if isChange}
                 <unsaved-changes-marker
-                  class="absolute right-0 top-0 w-4 h-4 bg-unsavedchange rounded-full translate-x-1/2 -translate-y-1/2"
+                  class="absolute right-0 top-0 w-4 h-4 bg-unsavedchange rounded-full translate-x-1/3 -translate-y-1/3"
                 />
               {/if}
             </button>

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -72,9 +72,6 @@
       });
     });
 
-    console.log(events);
-    console.log($unsaved_changes);
-
     selectedElement = target.element;
   }
 

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -33,7 +33,6 @@
 
   let syntaxError = false;
   let validationError = false;
-  let isChange = false;
 
   const dispatch = createEventDispatcher();
 
@@ -106,8 +105,6 @@
     <!-- TODO: Make marking when the block has unsaved changes  -->
     <div
       class="w-full flex flex-row pointer-events-none duration-300"
-      class:border-r-4={false}
-      class:border-unsavedchange={false}
     >
       <!-- Icon -->
       {#if config.information.hideIcon !== true}

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -3,6 +3,7 @@
 
   import { createEventDispatcher, onMount } from "svelte";
   import { ConfigList, ConfigObject } from "../Configuration.store";
+  import { unsaved_changes } from "../../../../runtime/runtime.store";
 
   import {
     lastOpenedActionblocks,
@@ -32,7 +33,17 @@
 
   let syntaxError = false;
   let validationError = false;
+  let isChange = false;
+
   const dispatch = createEventDispatcher();
+
+  $: handleUnsavedChangesChange($unsaved_changes);
+
+  function handleUnsavedChangesChange(changes) {
+    if (changes.length === 0) {
+      isChange = false;
+    }
+  }
 
   function replace_me(e) {
     const name = e.detail;
@@ -57,6 +68,7 @@
       short: e.detail.short,
       script: e.detail.script,
     });
+    isChange = true;
   }
 
   function handleValidator(e) {
@@ -99,7 +111,11 @@
     on:click|self={handleToggle}
   >
     <!-- Face of the config block, with disabled pointer events (Except for input fields) -->
-    <div class="w-full flex flex-row pointer-events-none duration-300">
+    <!-- TODO: Make marking when the block has unsaved changes  -->
+    <div
+      class="w-full flex flex-row pointer-events-none duration-300 border-unsavedchange"
+      class:border-r-4={isChange}
+    >
       <!-- Icon -->
       {#if config.information.hideIcon !== true}
         <div

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -37,14 +37,6 @@
 
   const dispatch = createEventDispatcher();
 
-  $: handleUnsavedChangesChange($unsaved_changes);
-
-  function handleUnsavedChangesChange(changes) {
-    if (changes.length === 0) {
-      isChange = false;
-    }
-  }
-
   function replace_me(e) {
     const name = e.detail;
     const components = getAllComponents();
@@ -113,8 +105,9 @@
     <!-- Face of the config block, with disabled pointer events (Except for input fields) -->
     <!-- TODO: Make marking when the block has unsaved changes  -->
     <div
-      class="w-full flex flex-row pointer-events-none duration-300 border-unsavedchange"
-      class:border-r-4={isChange}
+      class="w-full flex flex-row pointer-events-none duration-300"
+      class:border-r-4={false}
+      class:border-unsavedchange={false}
     >
       <!-- Icon -->
       {#if config.information.hideIcon !== true}

--- a/src/renderer/serialport/instructions.js
+++ b/src/renderer/serialport/instructions.js
@@ -116,28 +116,33 @@ const instructions = {
       return;
     }
 
-    const objIndex = get(unsaved_changes).findIndex(
-      (e) =>
-        e.x == dx &&
-        e.y == dy &&
-        e.page == page &&
-        e.element == element &&
-        e.event == event
-    );
-    if (objIndex !== -1) {
-      unsaved_changes.update((s) => {
-        const updatedChanges = [...s];
-        updatedChanges[objIndex].changes += 1;
-        return updatedChanges;
-      });
-    } else {
-      unsaved_changes.update((s) => [
-        ...s,
-        { x: dx, y: dy, page, element: element, event: event, changes: 1 },
-      ]);
-    }
+    //Was no previous change under this event
 
-    console.log(get(unsaved_changes));
+    unsaved_changes.update((s) => {
+      let obj = get(unsaved_changes).find(
+        (e) =>
+          e.x == dx &&
+          e.y == dy &&
+          e.page == page &&
+          e.element == element &&
+          e.event == event
+      );
+
+      if (typeof obj === "undefined") {
+        obj = {
+          x: dx,
+          y: dy,
+          page,
+          element: element,
+          event: event,
+          changes: 0,
+        };
+        s.push(obj);
+      }
+
+      obj.changes += 1;
+      return s;
+    });
 
     let buffer_element = {
       descr: {

--- a/src/renderer/serialport/instructions.js
+++ b/src/renderer/serialport/instructions.js
@@ -117,7 +117,12 @@ const instructions = {
     }
 
     const objIndex = get(unsaved_changes).findIndex(
-      (e) => e.x == dx && e.y == dy
+      (e) =>
+        e.x == dx &&
+        e.y == dy &&
+        e.page == page &&
+        e.element == element &&
+        e.event == event
     );
     if (objIndex !== -1) {
       unsaved_changes.update((s) => {
@@ -126,8 +131,13 @@ const instructions = {
         return updatedChanges;
       });
     } else {
-      unsaved_changes.update((s) => [...s, { x: dx, y: dy, changes: 1 }]);
+      unsaved_changes.update((s) => [
+        ...s,
+        { x: dx, y: dy, page, element: element, event: event, changes: 1 },
+      ]);
     }
+
+    console.log(get(unsaved_changes));
 
     let buffer_element = {
       descr: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -117,6 +117,9 @@ const config = {
           "desaturate-10": "#1BA487",
           "desaturate-20": "#5DDCB9",
         },
+        unsavedchange: {
+          DEFAULT: "#1D4ED8",
+        },
         secondary: {
           DEFAULT: "#2a3439",
           "brightness-90": "#eaebeb",


### PR DESCRIPTION
Added initial desgin for unsaved changes tracking for elements. Make a change for any event under an element, and see the GridLayout for the unsaved change indicator.

The design is bare bones, so further changes may come as the feature developes.

Review, and propose ideas if possible.

closes #466 