### PR TITLE
Fixed local variable suggestions 

### DIFF
--- a/src/renderer/config-blocks/LedAnimationStart.svelte
+++ b/src/renderer/config-blocks/LedAnimationStart.svelte
@@ -52,10 +52,11 @@
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
 
   import { Script } from "./_script_parsers.js";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import { Validator } from "./_validators";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
 
   export let config;
   export let humanScript;
@@ -146,9 +147,15 @@
 
   let suggestions = [];
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
+
     suggestions = _suggestions.map((s, i) => {
-      return [...s, ...$localDefinitions];
+      return [...s, ...localDefinitions];
     });
     suggestions = suggestions;
   }

--- a/src/renderer/config-blocks/LedAnimationStop.svelte
+++ b/src/renderer/config-blocks/LedAnimationStop.svelte
@@ -52,10 +52,11 @@
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
 
   import { Script } from "./_script_parsers.js";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import { Validator } from "./_validators";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
 
   export let config;
   export let humanScript;
@@ -146,11 +147,13 @@
 
   let suggestions = [];
 
-  $: if ($localDefinitions) {
-    suggestions = _suggestions.map((s, i) => {
-      return [...s, ...$localDefinitions];
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
     });
-    suggestions = suggestions;
+    suggestions = _suggestions.map((s) => [...s, ...localDefinitions]);
   }
 
   onMount(() => {

--- a/src/renderer/config-blocks/LedColor.svelte
+++ b/src/renderer/config-blocks/LedColor.svelte
@@ -50,6 +50,7 @@ A -> B : AB-First step
   import { onMount, createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
   import Toggle from "../main/user-interface/Toggle.svelte";
 
   import SendFeedback from "../main/user-interface/SendFeedback.svelte";
@@ -57,7 +58,7 @@ A -> B : AB-First step
   import { Validator } from "./_validators";
 
   import { Script } from "./_script_parsers.js";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   export let config;
   export let inputSet;
@@ -161,16 +162,20 @@ A -> B : AB-First step
 
   let suggestions = [];
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
     suggestions = _suggestions.map((s, i) => {
       // SKIP LAYER
       if (i != 1) {
-        return [...$localDefinitions, ...s];
+        return [...localDefinitions, ...s];
       } else {
-        return [...s, ...$localDefinitions];
+        return [...s, ...localDefinitions];
       }
     });
-    suggestions = suggestions;
   }
 
   onMount(() => {

--- a/src/renderer/config-blocks/LedPhase.svelte
+++ b/src/renderer/config-blocks/LedPhase.svelte
@@ -51,10 +51,11 @@
   import { onMount, createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import { Script } from "./_script_parsers.js";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import { Validator } from "./_validators";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
 
   export let config;
   export let humanScript;
@@ -124,16 +125,20 @@
 
   let suggestions = [];
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
     suggestions = _suggestions.map((s, i) => {
       // SKIP LAYER
       if (i != 1) {
-        return [...$localDefinitions, ...s];
+        return [...localDefinitions, ...s];
       } else {
-        return [...s, ...$localDefinitions];
+        return [...s, ...localDefinitions];
       }
     });
-    suggestions = suggestions;
   }
 
   onMount(() => {

--- a/src/renderer/config-blocks/Lookup.svelte
+++ b/src/renderer/config-blocks/Lookup.svelte
@@ -38,7 +38,8 @@
   import { createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import { Validator } from "./_validators";
   import { Script } from "./_script_parsers.js";

--- a/src/renderer/config-blocks/Midi.svelte
+++ b/src/renderer/config-blocks/Midi.svelte
@@ -677,11 +677,29 @@
       console.warn("error while creating midi suggetions");
       suggestions = _suggestions;
     }
+
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    let [start, end] = [index, index];
+    while (
+      start > 0 &&
+      $configManager[start].indentation === config.indentation
+    ) {
+      --start;
+    }
+    while (
+      end < $configManager.length &&
+      $configManager[end].indentation === config.indentation
+    ) {
+      ++end;
+    }
+    const list = $configManager.slice(start, end + 1);
+    localDefinitions.update(list);
+    suggestions = suggestions.map((s) => [...$localDefinitions, ...s]);
+    console.log(suggestions);
   }
 
   $: if (scriptSegments || $localDefinitions) {
     renderSuggestions();
-    suggestions = suggestions.map((s) => [...$localDefinitions, ...s]);
   }
 
   onMount(() => {
@@ -701,23 +719,7 @@
   let suggestionElement = undefined;
 
   function handleInputFocus() {
-    const index = $configManager.findIndex((e) => e.id === config.id);
-    let [start, end] = [index, index];
-    while (
-      start > 0 &&
-      $configManager[start].indentation === config.indentation
-    ) {
-      --start;
-    }
-    while (
-      end < $configManager.length &&
-      $configManager[end].indentation === config.indentation
-    ) {
-      ++end;
-    }
-    const list = $configManager.slice(start, end + 1);
-    localDefinitions.update(list);
-    console.log($localDefinitions);
+    renderSuggestions();
   }
 </script>
 

--- a/src/renderer/config-blocks/Midi.svelte
+++ b/src/renderer/config-blocks/Midi.svelte
@@ -58,6 +58,7 @@
   import SendFeedback from "../main/user-interface/SendFeedback.svelte";
   import TabButton from "../main/user-interface/TabButton.svelte";
   import { MusicalNotes } from "../main/panels/MidiMonitor/MidiMonitor.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
 
   let loaded = false;
 
@@ -698,6 +699,26 @@
   }
 
   let suggestionElement = undefined;
+
+  function handleInputFocus() {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    let [start, end] = [index, index];
+    while (
+      start > 0 &&
+      $configManager[start].indentation === config.indentation
+    ) {
+      --start;
+    }
+    while (
+      end < $configManager.length &&
+      $configManager[end].indentation === config.indentation
+    ) {
+      ++end;
+    }
+    const list = $configManager.slice(start, end + 1);
+    localDefinitions.update(list);
+    console.log($localDefinitions);
+  }
 </script>
 
 <action-midi
@@ -727,6 +748,7 @@
           suggestions={suggestions[i]}
           validator={validators[i]}
           suggestionTarget={suggestionElement}
+          on:focus={handleInputFocus}
           on:validator={(e) => {
             const data = e.detail;
             dispatch("validator", data);

--- a/src/renderer/config-blocks/MidiFourteenBit.svelte
+++ b/src/renderer/config-blocks/MidiFourteenBit.svelte
@@ -47,7 +47,8 @@
   import { onMount, createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import { Validator } from "./_validators";
 
@@ -671,18 +672,20 @@
   let suggestions = [];
 
   function renderSuggestions() {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
+
     suggestions[0] = _suggestions[0];
     suggestions[1] = _suggestions[1];
-    suggestions[2] = [...$localDefinitions];
+    suggestions[2] = [...localDefinitions];
   }
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
     renderSuggestions();
   }
-
-  onMount(() => {
-    renderSuggestions();
-  });
 
   const tabs = [
     { name: "MIDI", short: "gms" },

--- a/src/renderer/config-blocks/MouseButton.svelte
+++ b/src/renderer/config-blocks/MouseButton.svelte
@@ -35,6 +35,7 @@
   import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Script } from "./_script_parsers.js";
   import { Validator } from "./_validators";
 

--- a/src/renderer/config-blocks/MouseMove.svelte
+++ b/src/renderer/config-blocks/MouseMove.svelte
@@ -36,9 +36,10 @@
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
 
   import { Script } from "./_script_parsers.js";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
 
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
 
   import { Validator } from "./_validators";
 
@@ -94,11 +95,15 @@
     ],
   ];
 
-  $: if ($localDefinitions) {
-    suggestions = _suggestions.map((s, i) => {
-      return [...s, ...$localDefinitions];
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
     });
-    suggestions = suggestions;
+    suggestions = _suggestions.map((s, i) => {
+      return [...s, ...localDefinitions];
+    });
   }
 
   onMount(() => {

--- a/src/renderer/config-blocks/SettingsButton.svelte
+++ b/src/renderer/config-blocks/SettingsButton.svelte
@@ -27,6 +27,7 @@
   import { createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
   export let config = "";

--- a/src/renderer/config-blocks/SettingsEncoder.svelte
+++ b/src/renderer/config-blocks/SettingsEncoder.svelte
@@ -27,6 +27,7 @@
   import { createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
   export let config = "";

--- a/src/renderer/config-blocks/SettingsPotmeter.svelte
+++ b/src/renderer/config-blocks/SettingsPotmeter.svelte
@@ -27,6 +27,7 @@
   import { createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
   export let config = "";

--- a/src/renderer/config-blocks/TimerSource.svelte
+++ b/src/renderer/config-blocks/TimerSource.svelte
@@ -38,7 +38,8 @@
   import { Script } from "./_script_parsers.js";
 
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
   import { Validator } from "./_validators";
 
   export let config;
@@ -88,12 +89,16 @@
 
   let suggestions;
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
     suggestions = _suggestions.map((s, i) => {
       // SKIP LAYER
-      return [...s, ...$localDefinitions];
+      return [...s, ...localDefinitions];
     });
-    suggestions = suggestions;
   }
 
   onDestroy(() => {

--- a/src/renderer/config-blocks/TimerStart.svelte
+++ b/src/renderer/config-blocks/TimerStart.svelte
@@ -38,7 +38,8 @@
   import { Script } from "./_script_parsers.js";
 
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
   import { Validator } from "./_validators";
 
   export let config;
@@ -81,12 +82,16 @@
 
   const _suggestions = [[], []];
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
     suggestions = _suggestions.map((s, i) => {
       // SKIP LAYER
-      return [...s, ...$localDefinitions];
+      return [...s, ...localDefinitions];
     });
-    suggestions = suggestions;
   }
 
   let suggestionElement = undefined;

--- a/src/renderer/config-blocks/TimerStop.svelte
+++ b/src/renderer/config-blocks/TimerStop.svelte
@@ -35,7 +35,8 @@
   import { onMount, createEventDispatcher, onDestroy } from "svelte";
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import AtomicSuggestions from "../main/user-interface/AtomicSuggestions.svelte";
-  import { localDefinitions } from "../runtime/runtime.store";
+  import { configManager } from "../main/panels/configuration/Configuration.store";
+  import { LocalDefinitions } from "../runtime/runtime.store";
   import { Validator } from "./_validators";
 
   export let config;
@@ -69,12 +70,16 @@
 
   const _suggestions = [[]];
 
-  $: if ($localDefinitions) {
+  $: if ($configManager) {
+    const index = $configManager.findIndex((e) => e.id === config.id);
+    const localDefinitions = LocalDefinitions.getFrom({
+      configs: $configManager,
+      index: index,
+    });
     suggestions = _suggestions.map((s, i) => {
       // SKIP LAYER
-      return [...s, ...$localDefinitions];
+      return [...s, ...localDefinitions];
     });
-    suggestions = suggestions;
   }
 
   let suggestionElement = undefined;

--- a/src/renderer/main/ErrorConsole.svelte
+++ b/src/renderer/main/ErrorConsole.svelte
@@ -92,6 +92,7 @@
       text = "Ctrl + Shift + R";
     }
 
+    /*
     window.electron
       .fetchUrlJSON(configuration.NOTIFICATION_JSON_URL)
       .then((data) => {
@@ -115,6 +116,7 @@
       .catch((error) => {
         console.log("Fetching solutions failed", error);
       });
+      */
   });
 
   function refresh() {

--- a/src/renderer/main/ErrorConsole.svelte
+++ b/src/renderer/main/ErrorConsole.svelte
@@ -92,7 +92,6 @@
       text = "Ctrl + Shift + R";
     }
 
-    /*
     window.electron
       .fetchUrlJSON(configuration.NOTIFICATION_JSON_URL)
       .then((data) => {
@@ -116,7 +115,6 @@
       .catch((error) => {
         console.log("Fetching solutions failed", error);
       });
-      */
   });
 
   function refresh() {

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -112,7 +112,6 @@
 
   function handlePresetLoad(e) {
     const { elementNumber } = e.detail;
-    console.log(device);
     configManager.loadPreset({
       x: device.dx,
       y: device.dy,

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -453,7 +453,6 @@ function create_configuration_manager() {
   }
 
   function update(func) {
-    console.log("yay");
     store.update(func);
     store.update((store) => {
       ConfigList.setIndentation(store);

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -187,24 +187,21 @@ export class ConfigList extends Array {
     return copy;
   }
 
-  static getIndentationMap(list) {
-    let indentationMap = [];
+  static setIndentation(list) {
     let indentation = 0;
-
     for (let i = 0; i < list.length; i++) {
       let config = list[i];
 
       if (config.information.type === "composite_open") {
-        indentationMap.push(indentation++);
+        config.indentation = indentation++;
       } else if (config.information.type === "composite_close") {
-        indentationMap.push(--indentation);
+        config.indentation = --indentation;
       } else if (config.information.type === "composite_part") {
-        indentationMap.push(indentation - 1);
+        config.indentation = indentation - 1;
       } else {
-        indentationMap.push(indentation);
+        config.indentation = indentation;
       }
     }
-    return indentationMap;
   }
 
   static createFromTarget(target) {
@@ -438,7 +435,9 @@ function create_configuration_manager() {
   }
 
   user_input.subscribe((ui) => {
-    store.set(createConfigListFrom(ui));
+    store.update((store) => {
+      return createConfigListFrom(ui);
+    });
   });
 
   function loadPreset({ x, y, element, preset }) {
@@ -453,8 +452,18 @@ function create_configuration_manager() {
     store.set(createConfigListFrom(ui));
   }
 
+  function update(func) {
+    console.log("yay");
+    store.update(func);
+    store.update((store) => {
+      ConfigList.setIndentation(store);
+      return store;
+    });
+  }
+
   return {
     ...store,
+    update: update,
     loadPreset: loadPreset,
     loadProfile: loadProfile,
   };

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -87,7 +87,7 @@
   //////////////////////////////////////////////////////////////////////////////
 
   function updateLocalSuggestions(list) {
-    localDefinitions.update(list);
+    //localDefinitions.update(list);
   }
 
   function sendCurrentConfigurationToGrid() {
@@ -148,12 +148,7 @@
     if (typeof list === "undefined") {
       return;
     }
-
-    const map = ConfigList.getIndentationMap(list);
-    for (const i in map) {
-      list[i].indentation = map[i];
-    }
-
+    //ConfigList.setIndentation(list);
     updateLocalSuggestions(list);
   }
 

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -18,7 +18,6 @@
     user_input,
     appActionClipboard,
     controlElementClipboard,
-    localDefinitions,
   } from "../../../runtime/runtime.store.js";
 
   import { writeBuffer } from "../../../runtime/engine.store.js";
@@ -86,10 +85,6 @@
   /////////////////       FUNCTION DEFINITIONS        //////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  function updateLocalSuggestions(list) {
-    //localDefinitions.update(list);
-  }
-
   function sendCurrentConfigurationToGrid() {
     $configManager
       .sendTo({ target: ConfigTarget.createFrom({ userInput: $user_input }) })
@@ -148,8 +143,6 @@
     if (typeof list === "undefined") {
       return;
     }
-    //ConfigList.setIndentation(list);
-    updateLocalSuggestions(list);
   }
 
   function handleError(e) {

--- a/src/renderer/main/user-interface/AtomicInput.svelte
+++ b/src/renderer/main/user-interface/AtomicInput.svelte
@@ -56,6 +56,17 @@
 
   function handleFocus(e) {
     dispatch("focus");
+    updateSuggestions();
+  }
+
+  $: {
+    if (suggestions) {
+      updateSuggestions();
+    }
+  }
+
+  function updateSuggestions() {
+    console.log("sending", suggestions);
     if (typeof suggestionTarget !== "undefined") {
       const event = new CustomEvent("display", {
         detail: {

--- a/src/renderer/main/user-interface/AtomicInput.svelte
+++ b/src/renderer/main/user-interface/AtomicInput.svelte
@@ -59,14 +59,7 @@
     updateSuggestions();
   }
 
-  $: {
-    if (suggestions) {
-      updateSuggestions();
-    }
-  }
-
   function updateSuggestions() {
-    console.log("sending", suggestions);
     if (typeof suggestionTarget !== "undefined") {
       const event = new CustomEvent("display", {
         detail: {

--- a/src/renderer/main/user-interface/AtomicInput.svelte
+++ b/src/renderer/main/user-interface/AtomicInput.svelte
@@ -55,6 +55,7 @@
   }
 
   function handleFocus(e) {
+    dispatch("focus");
     if (typeof suggestionTarget !== "undefined") {
       const event = new CustomEvent("display", {
         detail: {

--- a/src/renderer/main/user-interface/AtomicSuggestions.svelte
+++ b/src/renderer/main/user-interface/AtomicSuggestions.svelte
@@ -10,7 +10,6 @@
   function handleDisplay(e) {
     const { data, sender } = e.detail;
     target = sender;
-    console.log("receive", data);
     suggestions = data;
   }
 

--- a/src/renderer/main/user-interface/AtomicSuggestions.svelte
+++ b/src/renderer/main/user-interface/AtomicSuggestions.svelte
@@ -10,6 +10,7 @@
   function handleDisplay(e) {
     const { data, sender } = e.detail;
     target = sender;
+    console.log("receive", data);
     suggestions = data;
   }
 

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -1272,32 +1272,37 @@ const editor_heartbeat_interval_handler = async function () {
 
 setIntervalAsync(editor_heartbeat_interval_handler, heartbeat_editor_ms);
 
-function createLocalDefinitions() {
-  const store = writable([]);
-
-  return {
-    ...store,
-    update: (configs) => {
-      let arr = [];
-      console.log(configs);
-
-      configs.forEach((c) => {
-        if (c.short == "l" && c.script !== "") {
-          let _variable_array = c.script.split("=")[0];
-          _variable_array = _variable_array.split("local")[1];
-          _variable_array = _variable_array.split(",");
-          _variable_array.forEach((val, i) => {
-            arr.push({ info: `local - ${val.trim()}`, value: val.trim() });
-          });
+export class LocalDefinitions {
+  static getFrom({ configs, index }) {
+    const config = configs[index];
+    let n = index - 1;
+    let list = [];
+    let indentation = config.indentation;
+    while (n >= 0) {
+      if (configs[n].indentation <= indentation) {
+        list.push(configs[n]);
+        if (configs[n].indentation != indentation) {
+          indentation = configs[n].indentation;
         }
-      });
+      }
+      --n;
+    }
 
-      store.set(arr);
-    },
-  };
+    let arr = [];
+    list.forEach((c) => {
+      if (c.short == "l" && c.script !== "") {
+        let _variable_array = c.script.split("=")[0];
+        _variable_array = _variable_array.split("local")[1];
+        _variable_array = _variable_array.split(",");
+        _variable_array.forEach((val, i) => {
+          arr.push({ info: `local - ${val.trim()}`, value: val.trim() });
+        });
+      }
+    });
+    console.log(index, arr);
+    return arr;
+  }
 }
-
-export const localDefinitions = createLocalDefinitions();
 
 export async function wss_send_message(message) {
   window.electron.websocket.transmit({ event: "message", data: message });

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -1161,7 +1161,6 @@ function create_runtime() {
     instructions.sendPageStoreToGrid();
     _runtime.update((store) => {
       store.forEach((device) => {
-        console.log(device);
         device.pages
           .find((e) => e.pageNumber == index)
           ?.control_elements.forEach((element) => {

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -1280,6 +1280,7 @@ function createLocalDefinitions() {
     ...store,
     update: (configs) => {
       let arr = [];
+      console.log(configs);
 
       configs.forEach((c) => {
         if (c.short == "l" && c.script !== "") {

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -1299,7 +1299,6 @@ export class LocalDefinitions {
         });
       }
     });
-    console.log(index, arr);
     return arr;
   }
 }


### PR DESCRIPTION
Closes #461 

Local suggestions are now reworked.
Previously the anytime a suggestions panel appears for an input field of an ActionBlock, all the defined local variables are displayed for selection. This is done regardless of whether it is defined in that context or not.

Examples when suggestions are showed, but should not (also see the original ticket for image):
midi block (a is suggested)
local.a = 3

if block
   local.b = 3
else block
   midi block (b is suggested)
end block

This behaviour is now fixed, and the suggestions are displayed according to its availability in that context, similarly to if it was written in code.