### PR TITLE
Fixed element overwrite change detection

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -465,21 +465,27 @@ function create_configuration_manager() {
 
   function loadPreset({ x, y, element, preset }) {
     return new Promise((resolve, reject) => {
-      runtime.element_preset_load(x, y, element, preset).then(() => {
-        const ui = get(user_input);
-        store.set(createConfigListFrom(ui));
-        resolve();
-      });
+      const callback = () => {
+        runtime.element_preset_load(x, y, element, preset).then(() => {
+          const ui = get(user_input);
+          store.set(createConfigListFrom(ui));
+          resolve();
+        });
+      };
+      runtime.fetch_element_configuration_from_grid(callback);
     });
   }
 
   function loadProfile({ x, y, profile }) {
     return new Promise((resolve) => {
-      runtime.whole_page_overwrite(x, y, profile).then(() => {
-        const ui = get(user_input);
-        store.set(createConfigListFrom(ui));
-        resolve();
-      });
+      const callback = () => {
+        runtime.whole_page_overwrite(x, y, profile).then(() => {
+          const ui = get(user_input);
+          store.set(createConfigListFrom(ui));
+          resolve();
+        });
+      };
+      runtime.fetch_page_configuration_from_grid(callback);
     });
   }
 

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -220,25 +220,35 @@ export class ConfigList extends Array {
       this.checkLength();
       const actionString = this.toConfigScript();
 
-      runtime.update_event_configuration(
+      const callback = () => {
+        runtime.update_event_configuration(
+          target.device.dx,
+          target.device.dy,
+          target.page,
+          target.element,
+          target.eventType,
+          actionString,
+          "EDITOR_EXECUTE"
+        );
+
+        runtime.send_event_configuration_to_grid(
+          target.device.dx,
+          target.device.dy,
+          target.page,
+          target.element,
+          target.eventType
+        );
+
+        resolve("Event sent to grid.");
+      };
+      runtime.fetchOrLoadConfig(
         target.device.dx,
         target.device.dy,
         target.page,
         target.element,
         target.eventType,
-        actionString,
-        "EDITOR_EXECUTE"
+        callback
       );
-
-      runtime.send_event_configuration_to_grid(
-        target.device.dx,
-        target.device.dy,
-        target.page,
-        target.element,
-        target.eventType
-      );
-
-      resolve("Event sent to grid.");
     });
   }
 
@@ -382,8 +392,15 @@ export class ConfigTarget {
       cfgstatus != "EDITOR_BACKGROUND"
     ) {
       const ui = get(user_input);
+      const { dx, dy, page, element, event } = {
+        dx: ui.brc.dx,
+        dy: ui.brc.dy,
+        page: ui.event.pagenumber,
+        element: ui.event.elementnumber,
+        event: ui.event.eventtype,
+      };
       const callback = () => user_input.update((n) => n);
-      runtime.fetchOrLoadConfig(ui, callback);
+      runtime.fetchOrLoadConfig(dx, dy, page, element, event, callback);
     }
 
     return event.config;

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -387,19 +387,15 @@ function create_runtime() {
     return _event;
   };
 
-  function fetchOrLoadConfig(ui, callback) {
+  function fetchOrLoadConfig(dx, dy, page, element, event, callback) {
     //console.log("Fetch Or Load")
 
     const rt = get(runtime);
 
-    const device = rt.find(
-      (device) => device.dx == ui.brc.dx && device.dy == ui.brc.dy
-    );
-    const pageIndex = device.pages.findIndex(
-      (x) => x.pageNumber == ui.event.pagenumber
-    );
+    const device = rt.find((device) => device.dx == dx && device.dy == dy);
+    const pageIndex = device.pages.findIndex((x) => x.pageNumber == page);
     const elementIndex = device.pages[pageIndex].control_elements.findIndex(
-      (x) => x.controlElementNumber == ui.event.elementnumber
+      (x) => x.controlElementNumber == element
     );
 
     if (device.pages[pageIndex].control_elements[elementIndex] === undefined)
@@ -407,7 +403,7 @@ function create_runtime() {
 
     const eventIndex = device.pages[pageIndex].control_elements[
       elementIndex
-    ].events.findIndex((x) => x.event.value == ui.event.eventtype);
+    ].events.findIndex((x) => x.event.value == event);
 
     //console.log(device, pageIndex, elementIndex, eventIndex)
 
@@ -425,13 +421,6 @@ function create_runtime() {
         callback();
       }
     } else {
-      // fetch
-      const dx = ui.brc.dx;
-      const dy = ui.brc.dy;
-      const page = ui.event.pagenumber;
-      const element = ui.event.elementnumber;
-      const event = ui.event.eventtype;
-
       instructions.fetchConfigFromGrid(dx, dy, page, element, event, callback);
     }
 
@@ -776,6 +765,7 @@ function create_runtime() {
         if (typeof dest.stored === "undefined") {
           dest.stored = actionString;
         }
+        console.log(dest);
       }
       return _runtime;
     });
@@ -809,17 +799,21 @@ function create_runtime() {
 
   // whole element copy: fetches all event configs from a control element
   function fetch_element_configuration_from_grid(callback) {
-    const li = get(user_input);
+    const ui = get(user_input);
+    let { dx, dy, page, element, event } = {
+      dx: ui.brc.dx,
+      dy: ui.brc.dy,
+      page: ui.event.pagenumber,
+      element: ui.event.elementnumber,
+      event: ui.event.eventtype,
+    };
+
     const rt = get(runtime);
 
-    const device = rt.find(
-      (device) => device.dx == li.brc.dx && device.dy == li.brc.dy
-    );
-    const pageIndex = device.pages.findIndex(
-      (x) => x.pageNumber == li.event.pagenumber
-    );
+    const device = rt.find((device) => device.dx == dx && device.dy == dy);
+    const pageIndex = device.pages.findIndex((x) => x.pageNumber == page);
     const elementIndex = device.pages[pageIndex].control_elements.findIndex(
-      (x) => x.controlElementNumber == li.event.elementnumber
+      (x) => x.controlElementNumber == element
     );
 
     const events =
@@ -839,15 +833,17 @@ function create_runtime() {
     });
 
     array.forEach((elem, ind) => {
-      li.event.eventtype = elem.event;
-      li.event.elementnumber = elem.elementnumber;
+      ui.event.eventtype = elem.event;
+      ui.event.elementnumber = elem.elementnumber;
+      event = ui.event.eventtype;
+      element = ui.event.elementnumber;
 
       if (ind == array.length - 1 && callback !== undefined) {
         // this is last and callback is defined
 
-        fetchOrLoadConfig(li, callback);
+        fetchOrLoadConfig(dx, dy, page, element, event, callback);
       } else {
-        fetchOrLoadConfig(li);
+        fetchOrLoadConfig(dx, dy, page, element, event);
       }
     });
   }
@@ -864,11 +860,16 @@ function create_runtime() {
 
     const rt = get(runtime);
 
-    let li = Object.assign({}, get(user_input));
+    let ui = Object.assign({}, get(user_input));
+    let { dx, dy, page, element, event } = {
+      dx: ui.brc.dx,
+      dy: ui.brc.dy,
+      page: ui.event.pagenumber,
+      element: ui.event.elementnumber,
+      event: ui.event.eventtype,
+    };
 
-    let device = rt.find(
-      (device) => device.dx == li.brc.dx && device.dy == li.brc.dy
-    );
+    let device = rt.find((device) => device.dx == dx && device.dy == dy);
 
     if (typeof device === "undefined") {
       logger.set({
@@ -881,9 +882,7 @@ function create_runtime() {
       return;
     }
 
-    const pageIndex = device.pages.findIndex(
-      (x) => x.pageNumber == li.event.pagenumber
-    );
+    const pageIndex = device.pages.findIndex((x) => x.pageNumber == page);
     const controlElements = device.pages[pageIndex].control_elements;
 
     const fetchArray = [];
@@ -916,15 +915,16 @@ function create_runtime() {
       callback();
     } else {
       fetchArray.forEach((elem, ind) => {
-        li.event.eventtype = elem.event;
-        li.event.elementnumber = elem.elementnumber;
+        ui.event.eventtype = elem.event; //TODO: check
+        ui.event.elementnumber = elem.elementnumber;
+        event = ui.event.eventtype;
+        element = ui.event.elementnumber;
 
         if (ind === fetchArray.length - 1) {
           // last element
-
-          fetchOrLoadConfig(li, callback);
+          fetchOrLoadConfig(dx, dy, page, element, event, callback);
         } else {
-          fetchOrLoadConfig(li);
+          fetchOrLoadConfig(dx, dy, page, element, event);
         }
       });
     }


### PR DESCRIPTION
**As mentioned in discords #editor-qa channel:**

> "Init-en állítok egy led szín, utána whole element copy/overwrite segítségével másolnám többi elemre de az active change overlay az esetek nagyrészében nem triggerelődik"


**The issue was:**
Dumping configuration to a not yet fetched element (example: element overwrite) does not have a stored state, that is fetched when selecting the event, so there is nothing to be compared to when detecting active changes.

**Technical details of the fix:**
Fixed by reworking the event configuration fetching mechanism.
An event is always loaded before configurations can be sent to them.