### PR TITLE
Tooling update

### DIFF
--- a/.github/workflows/alpha-matrix.yml
+++ b/.github/workflows/alpha-matrix.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: "18.16.1"
 
       - name: Download profile cloud artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profile-cloud
           path: profile-cloud/
@@ -83,6 +83,7 @@ jobs:
 
           # Apple ID
           APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
           APPLE_APP_SPECIFIC_PASSWORD: ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
 
           # macOS Code signing
@@ -124,7 +125,7 @@ jobs:
           cat unit_test.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-unit-test
           path: unit_test.txt

--- a/.github/workflows/alpha-matrix.yml
+++ b/.github/workflows/alpha-matrix.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci && npm run build
 
       - name: Upload profile cloud folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: profile-cloud
           path: public/

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci && npm run build
 
       - name: Upload profile cloud folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: profile-cloud
           path: public/
@@ -56,7 +56,7 @@ jobs:
           node-version: "18.16.1"
 
       - name: Download profile cloud artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profile-cloud
           path: profile-cloud/
@@ -93,7 +93,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-nightly
           path: build/*.*
@@ -122,7 +122,7 @@ jobs:
           cat unit_test.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-unit-test
           path: unit_test.txt

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -85,6 +85,7 @@ jobs:
 
           # Apple ID
           APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
           APPLE_APP_SPECIFIC_PASSWORD: ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
 
           # macOS Code signing

--- a/.github/workflows/stable-matrix.yml
+++ b/.github/workflows/stable-matrix.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci && npm run build
 
       - name: Upload profile cloud folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: profile-cloud
           path: public/
@@ -61,7 +61,7 @@ jobs:
           node-version: "18.16.1"
 
       - name: Download profile cloud artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profile-cloud
           path: profile-cloud/
@@ -81,6 +81,7 @@ jobs:
 
           # Apple ID
           APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
           APPLE_APP_SPECIFIC_PASSWORD: ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
 
           # macOS Code signing


### PR DESCRIPTION
## New update to GitHub Actions
Upload and download artifacts are updated to `v4`. Now the build artifacts are uploaded/downlaoded separately, no need to wait for all jobs to finish to begin testing. [Read more here.](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new)

## MacOS notarytool requires teamId
Although uploaded to github secrets and already added to `notarize.js`, the `APPLE_TEAM_ID` was not used in the action scripts. If I remember correctly, I could not use it before as the notarization server was not working when team id was present. Since it's now ultimately required, added back to the scripts.

## Quit app resulting in crash
This branch uses one of the most recent stable branch. Alpha and nightly builds done on this branch don't have this issue anymore. I suspect that the package tab crash or some other background process crashing resulted in this error, which has been fixed in the meantime by @danim1130.