### PR TITLE
 Fixed element overwrite change detection (Part 2)

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -463,6 +463,7 @@ function create_configuration_manager() {
     });
   });
 
+  // TODO: fails to show overlay after clear
   function loadPreset({ x, y, element, preset }) {
     return new Promise((resolve, reject) => {
       const callback = () => {

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -426,7 +426,9 @@ export class ConfigTarget {
 export const configManager = create_configuration_manager();
 
 function create_configuration_manager() {
-  let store = writable(new ConfigList());
+  let store = derived(user_input, (ui) => {
+    return createConfigListFrom(ui);
+  });
 
   function createConfigListFrom(ui) {
     const target = ConfigTarget.createFrom({ userInput: ui });
@@ -456,13 +458,6 @@ function create_configuration_manager() {
     return list;
   }
 
-  user_input.subscribe((ui) => {
-    update((store) => {
-      return createConfigListFrom(ui);
-    });
-  });
-
-  // TODO: fails to show overlay after clear
   function loadPreset({ x, y, element, preset }) {
     return new Promise((resolve, reject) => {
       const callback = () => {

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -443,7 +443,9 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.element_preset_load(x, y, element, preset).then(() => {
           const ui = get(user_input);
-          const list = createConfigListFrom(ui);
+          const target = ConfigTarget.createFrom({ userInput: ui });
+          const list = ConfigList.createFromTarget(target);
+
           setOverride(list);
           resolve();
         });
@@ -471,7 +473,8 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.whole_page_overwrite(x, y, profile).then(() => {
           const ui = get(user_input);
-          const list = createConfigListFrom(ui);
+          const target = ConfigTarget.createFrom({ userInput: ui });
+          const list = ConfigList.createFromTarget(target);
           setOverride(list);
           resolve();
         });

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -468,7 +468,9 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.element_preset_load(x, y, element, preset).then(() => {
           const ui = get(user_input);
-          set(createConfigListFrom(ui));
+          let list = createConfigListFrom(ui);
+          list = afterUpdate(list);
+          store.set(list);
           resolve();
         });
       };
@@ -495,7 +497,9 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.whole_page_overwrite(x, y, profile).then(() => {
           const ui = get(user_input);
-          set(createConfigListFrom(ui));
+          let list = createConfigListFrom(ui);
+          list = afterUpdate(list);
+          store.set(list);
           resolve();
         });
       };
@@ -503,10 +507,15 @@ function create_configuration_manager() {
     });
   }
 
+  function afterUpdate(store) {
+    ConfigList.setIndentation(store);
+    return store;
+  }
+
   function update(func) {
-    store.update(func);
     store.update((store) => {
-      ConfigList.setIndentation(store);
+      store = func(store);
+      store = afterUpdate(store);
       return store;
     });
   }
@@ -514,7 +523,7 @@ function create_configuration_manager() {
   function set(obj) {
     store.update((store) => {
       store = obj.makeCopy();
-      ConfigList.setIndentation(store);
+      store = afterUpdate(store);
       return store;
     });
   }

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -468,9 +468,8 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.element_preset_load(x, y, element, preset).then(() => {
           const ui = get(user_input);
-          let list = createConfigListFrom(ui);
-          list = afterUpdate(list);
-          store.set(list);
+          const list = createConfigListFrom(ui);
+          setOverride(list);
           resolve();
         });
       };
@@ -497,9 +496,8 @@ function create_configuration_manager() {
       const callback = () => {
         runtime.whole_page_overwrite(x, y, profile).then(() => {
           const ui = get(user_input);
-          let list = createConfigListFrom(ui);
-          list = afterUpdate(list);
-          store.set(list);
+          const list = createConfigListFrom(ui);
+          setOverride(list);
           resolve();
         });
       };
@@ -512,7 +510,7 @@ function create_configuration_manager() {
     return store;
   }
 
-  function update(func) {
+  function updateOverride(func) {
     store.update((store) => {
       store = func(store);
       store = afterUpdate(store);
@@ -520,7 +518,7 @@ function create_configuration_manager() {
     });
   }
 
-  function set(obj) {
+  function setOverride(obj) {
     store.update((store) => {
       store = obj.makeCopy();
       store = afterUpdate(store);
@@ -530,8 +528,8 @@ function create_configuration_manager() {
 
   return {
     ...store,
-    update: update,
-    set: set,
+    update: updateOverride,
+    set: setOverride,
     loadPreset: loadPreset,
     loadProfile: loadProfile,
   };

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -354,8 +354,9 @@
 
   function handleCopyAll() {
     //Callback function
-    let callback = function () {
-      const current = ConfigTarget.createFrom({ userInput: $user_input });
+    const ui = get(user_input);
+    let callback = () => {
+      const current = ConfigTarget.createFrom({ userInput: ui });
       const configsLists = [];
       current.events.forEach((e) => {
         const eventType = e.event.value;
@@ -389,7 +390,20 @@
     });
 
     //Fetching all unloaded elements configuration
-    runtime.fetch_element_configuration_from_grid(callback);
+    const { dx, dy, page, element } = {
+      dx: ui.brc.dx,
+      dy: ui.brc.dy,
+      page: ui.event.pagenumber,
+      element: ui.event.elementnumber,
+    };
+
+    runtime.fetch_element_configuration_from_grid(
+      dx,
+      dy,
+      page,
+      element,
+      callback
+    );
 
     Analytics.track({
       event: "Config Action",

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -388,7 +388,7 @@ function create_runtime() {
   };
 
   function fetchOrLoadConfig(dx, dy, page, element, event, callback) {
-    //console.log("Fetch Or Load")
+    //console.log("Fetch Or Load");
 
     const rt = get(runtime);
 
@@ -810,52 +810,35 @@ function create_runtime() {
   }
 
   // whole element copy: fetches all event configs from a control element
-  function fetch_element_configuration_from_grid(callback) {
-    const ui = get(user_input);
-    let { dx, dy, page, element, event } = {
-      dx: ui.brc.dx,
-      dy: ui.brc.dy,
-      page: ui.event.pagenumber,
-      element: ui.event.elementnumber,
-      event: ui.event.eventtype,
-    };
-
+  function fetch_element_configuration_from_grid(
+    dx,
+    dy,
+    pageNumber,
+    elementNumber,
+    callback
+  ) {
     const rt = get(runtime);
-
     const device = rt.find((device) => device.dx == dx && device.dy == dy);
-    const pageIndex = device.pages.findIndex((x) => x.pageNumber == page);
-    const elementIndex = device.pages[pageIndex].control_elements.findIndex(
-      (x) => x.controlElementNumber == element
+    const page = device.pages.find((x) => x.pageNumber == pageNumber);
+    const element = page.control_elements.find(
+      (x) => x.controlElementNumber == elementNumber
     );
+    const events = element.events;
 
-    const events =
-      device.pages[pageIndex].control_elements[elementIndex].events;
-    const controlElementType =
-      device.pages[pageIndex].control_elements[elementIndex].controlElementType;
-
-    const array = [];
-
-    events.forEach((e) => {
-      array.push({
-        event: e.event.value,
-        elementnumber:
-          device.pages[pageIndex].control_elements[elementIndex]
-            .controlElementNumber,
-      });
-    });
-
-    array.forEach((elem, ind) => {
-      ui.event.eventtype = elem.event;
-      ui.event.elementnumber = elem.elementnumber;
-      event = ui.event.eventtype;
-      element = ui.event.elementnumber;
-
-      if (ind == array.length - 1 && callback !== undefined) {
+    events.forEach((e, i) => {
+      const eventNumber = Number(e.event.value);
+      if (i == events.length - 1 && typeof callback !== "undefined") {
         // this is last and callback is defined
-
-        fetchOrLoadConfig(dx, dy, page, element, event, callback);
+        fetchOrLoadConfig(
+          dx,
+          dy,
+          pageNumber,
+          elementNumber,
+          eventNumber,
+          callback
+        );
       } else {
-        fetchOrLoadConfig(dx, dy, page, element, event);
+        fetchOrLoadConfig(dx, dy, pageNumber, elementNumber, eventNumber);
       }
     });
   }

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -701,7 +701,7 @@ function create_runtime() {
         array.unshift(objectToMove);
       }
 
-      let li = get(user_input);
+      let li = structuredClone(get(user_input));
       array.forEach((elem, elementIndex) => {
         elem.events.forEach((ev, eventIndex) => {
           li.event.pagenumber = li.event.pagenumber;


### PR DESCRIPTION
**Previous PR merged due to release pressure! One identified issue still needs to be fixed:**

@kkerti  Tested with 1x EF44 + 1x PBF4, side by side.

Scenarios tested:
- [x] change control element init color, copy all, overwrite to other control elements (fader on pbf4)
- [x] change potmeter event (second event for triggering active change), copy all, overwrite to others (fader on pbf4)
- [x] move changed configuration from pbf4 to ef44, see appropiate events showing active changes
- [x] create element preset, no changes triggered
- [x] create module profile, no changes triggered
- [x] load element preset to appropriate element and see the active changes properly trigger
- [ ] after element preset is loaded, **THEN cleared**, new preset loads are not detected correctly

