### PR TITLE
Group hover visual bug is no longer present for variable action blocks

### DIFF
--- a/src/renderer/config-blocks/headers/MidiFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiFace.svelte
@@ -28,8 +28,10 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
-  class="{$$props.class} text-white flex items-center flex-row w-full px-2"
-  class:group-hover:bg-select-saturate-10={typeof $config_drag === "undefined"}
+  class="{$$props.class} text-white flex items-center flex-row w-full px-2 {typeof $config_drag ===
+  'undefined'
+    ? 'group-hover/bg-color:bg-select-saturate-10'
+    : ''}"
   on:click={handleClick}
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">

--- a/src/renderer/config-blocks/headers/MidiFourteenBitFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiFourteenBitFace.svelte
@@ -61,8 +61,10 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
-  class="{$$props.class} text-white flex items-center flex-row w-full px-2"
-  class:group-hover:bg-select-saturate-10={typeof $config_drag === "undefined"}
+  class="{$$props.class} text-white flex items-center flex-row w-full px-2 {typeof $config_drag ===
+  'undefined'
+    ? 'group-hover/bg-color:bg-select-saturate-10'
+    : ''}"
   on:click={handleClick}
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">

--- a/src/renderer/config-blocks/headers/MidiSysExFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiSysExFace.svelte
@@ -18,8 +18,10 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
-  class="{$$props.class} text-white flex items-center flex-row w-full px-2"
-  class:group-hover:bg-select-saturate-10={typeof $config_drag === "undefined"}
+  class="{$$props.class} text-white flex items-center flex-row w-full px-2 {typeof $config_drag ===
+  'undefined'
+    ? 'group-hover/bg-color:bg-select-saturate-10'
+    : ''}"
   on:click={handleClick}
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -14,8 +14,10 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
-  class="{$$props.class} text-white flex items-center bg-secondary"
-  class:group-hover:bg-select-saturate-10={typeof $config_drag === "undefined"}
+  class="{$$props.class} text-white flex items-center bg-secondary {typeof $config_drag ===
+  'undefined'
+    ? 'group-hover/bg-color:bg-select-saturate-10'
+    : ''}"
   on:click={handleClick}
 >
   <span>{config.information.blockTitle}</span>

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -97,7 +97,7 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <carousel
-    class="group flex flex-grow h-auto min-h-[32px]"
+    class="group/bg-color flex flex-grow h-auto min-h-[32px]"
     id="cfg-{index}"
     config-name={config.information.name}
     config-type={config.information.type}


### PR DESCRIPTION
Closes #514 

Self, Global, and Locale action blocks has no longer the visual bug of hovering the Add button when hovering the action block.
For details, see the original issue linked above.