### PR TITLE
Cleanup of user_input and runtime store

### DIFF
--- a/src/renderer/lib/_configs.js
+++ b/src/renderer/lib/_configs.js
@@ -19,8 +19,6 @@ export async function init_config_block_library() {
   }
 }
 
-init_config_block_library();
-
 export function getComponentInformation({ short }) {
   const comps = getAllComponents();
 

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -65,15 +65,12 @@
   }
 
   function selectElement(controlNumber) {
-    const elementType = device?.pages[0].control_elements.find(
-      (e) => e.controlElementNumber == controlNumber
-    ).controlElementType;
-    user_input.update((ui) => {
-      ui.brc.dx = +device?.dx;
-      ui.brc.dy = +device?.dy;
-      ui.event.elementnumber = +controlNumber;
-      ui.event.elementtype = elementType;
-      return ui;
+    user_input.set({
+      dx: device.dx,
+      dy: device.dy,
+      pagenumber: $user_input.pagenumber,
+      elementnumber: controlNumber,
+      eventtype: $user_input.eventtype,
     });
   }
 

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -66,8 +66,8 @@
 
   function selectElement(controlNumber) {
     user_input.set({
-      dx: device.dx,
-      dy: device.dy,
+      dx: device?.dx,
+      dy: device?.dy,
       pagenumber: $user_input.pagenumber,
       elementnumber: controlNumber,
       eventtype: $user_input.eventtype,

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -1,7 +1,9 @@
 <script>
-  import { runtime, user_input } from "./../../../../runtime/runtime.store.js";
+  import { ConfigTarget } from "./../../../panels/configuration/Configuration.store.js";
+  import { user_input } from "./../../../../runtime/runtime.store.js";
   import { selectedConfigStore } from "../../../../runtime/config-helper.store";
   import { createEventDispatcher } from "svelte";
+  import { get } from "svelte/store";
   import { appSettings } from "../../../../runtime/app-helper.store";
   import SvgIcon from "../../../user-interface/SvgIcon.svelte";
   import { scale } from "svelte/transition";
@@ -49,33 +51,30 @@
     loaded = success;
   }
 
-  let [dx, dy] = [device?.dx, device?.dy];
   let isChanged = false;
-  $: {
-    try {
-      const events = $runtime
-        .find((e) => e.dx == dx && e.dy == dy)
-        .pages[$user_input.event.pagenumber].control_elements.find(
-          (e) => e.controlElementNumber == elementNumber
-        ).events;
 
+  $: handleDeviceChange(device);
+
+  function handleDeviceChange(rt) {
+    const { dx, dy } = device;
+    const ui = get(user_input);
+    try {
+      const target = new ConfigTarget({
+        device: { dx: dx, dy: dy },
+        page: ui.pagenumber,
+        element: elementNumber,
+        eventType: 0,
+      });
+      const events = target.events;
       //Find the event that has change
       const changed = events.find(
-        (e) =>
-          e.cfgStatus !== "NULL" &&
-          e.cfgStatus !== "ERASED" &&
-          e.stored !== e.config
+        (e) => typeof e.stored !== "undefined" && e.stored !== e.config
       );
-
-      if (typeof changed !== "undefined") {
-        isChanged = true;
-      } else {
-        isChanged = false;
-      }
-    } catch (e) {}
+      isChanged = typeof changed !== "undefined";
+    } catch (e) {
+      isChanged = false;
+    }
   }
-
-  $: console.log(isChanged);
 </script>
 
 <container bind:this={container} on:preset-load={handlePresetLoad}>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -56,25 +56,28 @@
 
   $: handleDeviceChange(device);
 
-  function handleDeviceChange(rt) {
-    const { dx, dy } = device;
+  function handleDeviceChange(obj) {
+    const { dx, dy } = obj;
     const ui = get(user_input);
-    try {
-      const target = new ConfigTarget({
-        device: { dx: dx, dy: dy },
-        page: ui.pagenumber,
-        element: elementNumber,
-        eventType: 0,
-      });
-      const events = target.events;
-      //Find the event that has change
-      const changed = events.find(
-        (e) => typeof e.stored !== "undefined" && e.stored !== e.config
-      );
-      isChanged = typeof changed !== "undefined";
-    } catch (e) {
+
+    const target = new ConfigTarget({
+      device: { dx: dx, dy: dy },
+      page: ui.pagenumber,
+      element: elementNumber,
+      eventType: 0,
+    });
+
+    if (typeof target === "undefined") {
       isChanged = false;
+      return;
     }
+
+    const events = target.events;
+    //Find the event that has change
+    const changed = events.find(
+      (e) => typeof e.stored !== "undefined" && e.stored !== e.config
+    );
+    isChanged = typeof changed !== "undefined";
   }
 </script>
 

--- a/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
@@ -16,25 +16,28 @@
 
   $: handleDeviceChange(device);
 
-  function handleDeviceChange(rt) {
-    const { dx, dy } = device;
+  function handleDeviceChange(obj) {
+    const { dx, dy } = obj;
     const ui = get(user_input);
-    try {
-      const target = new ConfigTarget({
-        device: { dx: dx, dy: dy },
-        page: ui.pagenumber,
-        element: elementNumber,
-        eventType: 0,
-      });
-      const events = target.events;
-      //Find the event that has change
-      const changed = events.find(
-        (e) => typeof e.stored !== "undefined" && e.stored !== e.config
-      );
-      isChanged = typeof changed !== "undefined";
-    } catch (e) {
+
+    const target = new ConfigTarget({
+      device: { dx: dx, dy: dy },
+      page: ui.pagenumber,
+      element: elementNumber,
+      eventType: 0,
+    });
+
+    if (typeof target === "undefined") {
       isChanged = false;
+      return;
     }
+
+    const events = target.events;
+    //Find the event that has change
+    const changed = events.find(
+      (e) => typeof e.stored !== "undefined" && e.stored !== e.config
+    );
+    isChanged = typeof changed !== "undefined";
   }
 </script>
 

--- a/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
@@ -1,6 +1,8 @@
 <script>
-  import { runtime, user_input } from "../../../../runtime/runtime.store.js";
+  import { ConfigTarget } from "./../../../panels/configuration/Configuration.store.js";
+  import { user_input } from "../../../../runtime/runtime.store.js";
   import { createEventDispatcher } from "svelte";
+  import { get } from "svelte/store";
 
   export let elementNumber;
   export let isLeftCut;
@@ -10,32 +12,29 @@
 
   const dispatch = createEventDispatcher();
 
-  let [dx, dy] = [device?.dx, device?.dy];
-
   let isChanged = false;
-  $: {
-    try {
-      const events = $runtime
-        .find((e) => e.dx == dx && e.dy == dy)
-        .pages[$user_input.event.pagenumber].control_elements.find(
-          (e) => e.controlElementNumber == elementNumber
-        ).events;
 
+  $: handleDeviceChange(device);
+
+  function handleDeviceChange(rt) {
+    const { dx, dy } = device;
+    const ui = get(user_input);
+    try {
+      const target = new ConfigTarget({
+        device: { dx: dx, dy: dy },
+        page: ui.pagenumber,
+        element: elementNumber,
+        eventType: 0,
+      });
+      const events = target.events;
       //Find the event that has change
       const changed = events.find(
-        (e) =>
-          e.cfgStatus !== "NULL" &&
-          e.cfgStatus !== "ERASED" &&
-          typeof e.stored !== "undefined" &&
-          e.stored !== e.config
+        (e) => typeof e.stored !== "undefined" && e.stored !== e.config
       );
-
-      if (typeof changed !== "undefined") {
-        isChanged = true;
-      } else {
-        isChanged = false;
-      }
-    } catch (e) {}
+      isChanged = typeof changed !== "undefined";
+    } catch (e) {
+      isChanged = false;
+    }
   }
 </script>
 

--- a/src/renderer/main/grid-layout/grid-modules/underlays/ElementSelection.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/underlays/ElementSelection.svelte
@@ -1,5 +1,6 @@
 <script>
   import { user_input } from "../../../../runtime/runtime.store.js";
+  import { get } from "svelte/store";
   import { createEventDispatcher } from "svelte";
 
   export let elementNumber;
@@ -18,11 +19,11 @@
   }
 
   let isSelected = false;
-  $: {
+  $: handleUserInputChange($user_input);
+
+  function handleUserInputChange(ui) {
     isSelected =
-      dx == $user_input?.brc.dx &&
-      dy == $user_input?.brc.dy &&
-      $user_input?.event.elementnumber == elementNumber;
+      dx == ui?.dx && dy == ui?.dy && ui?.elementnumber == elementNumber;
   }
 </script>
 

--- a/src/renderer/main/grid-layout/grid-modules/underlays/ModuleBorder.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/underlays/ModuleBorder.svelte
@@ -7,20 +7,14 @@
   export let device = undefined;
   export let visible = false;
 
-  const dispatch = createEventDispatcher();
-
   let isSelected = false;
-  $: {
-    isSelected =
-      device?.dx == $user_input.brc.dx && device?.dy == $user_input.brc.dy;
-  }
-
   let isSystemEventsSelected = false;
-  $: {
-    isSystemEventsSelected =
-      $user_input.brc.dx == device?.dx &&
-      $user_input.brc.dy == device?.dy &&
-      $user_input.event.elementnumber == 255;
+
+  $: handleUserInputChange($user_input);
+
+  function handleUserInputChange(ui) {
+    isSelected = device?.dx == ui.dx && device?.dy == ui.dy;
+    isSystemEventsSelected = isSelected && ui.elementnumber == 255;
   }
 </script>
 

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -238,8 +238,7 @@ export class ConfigList extends Array {
           target.page,
           target.element,
           target.eventType,
-          actionString,
-          "EDITOR_EXECUTE"
+          actionString
         );
 
         runtime.send_event_configuration_to_grid(

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -11,7 +11,6 @@ import {
 
 import {
   getComponentInformation,
-  config_components,
   init_config_block_library,
 } from "../../../lib/_configs";
 
@@ -423,16 +422,21 @@ export const configManager = create_configuration_manager();
 
 function create_configuration_manager() {
   const internal = writable(new ConfigList());
-  const unsubscribeUserInput = user_input.subscribe((ui) => {
-    createConfigListFrom(ui)
-      .then((list) => {
-        setOverride(list);
-      })
-      .catch((e) => {
-        console.error(e);
-        setOverride(new ConfigList());
-      });
-  });
+  const loadAndInit = async () => {
+    await init_config_block_library();
+    const unsubscribeUserInput = user_input.subscribe((ui) => {
+      createConfigListFrom(ui)
+        .then((list) => {
+          setOverride(list);
+        })
+        .catch((e) => {
+          console.error(e);
+          setOverride(new ConfigList());
+        });
+    });
+  };
+
+  loadAndInit();
 
   async function createConfigListFrom(ui) {
     return new Promise(async (resolve, reject) => {

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -54,13 +54,6 @@ export class ConfigObject {
     this.script = script;
     this.id = uuidv4();
 
-    const init = async () => {
-      if (config_components == []) {
-        await init_config_block_library();
-      }
-    };
-    init();
-
     let res = getComponentInformation({ short: short });
 
     //Backward compatibility
@@ -163,13 +156,6 @@ export class ConfigObject {
   }
 }
 
-export class UnknownEventException extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "UnknownEventException";
-  }
-}
-
 export class ConfigList extends Array {
   makeCopy() {
     const copy = new ConfigList();
@@ -203,9 +189,35 @@ export class ConfigList extends Array {
     }
   }
 
-  static createFromTarget(target) {
-    let configScript = target.getActionString();
-    return ConfigList.createFromActionString(configScript);
+  static async createFromTarget(target) {
+    return new Promise(async (resolve, reject) => {
+      if (typeof target === "undefined") {
+        reject("ConfigTarget is undefined");
+        return;
+      }
+
+      const script = target.getConfig();
+
+      if (typeof script !== "undefined") {
+        resolve(ConfigList.createFromActionString(script));
+      } else {
+        await new Promise(async (resolve, reject) => {
+          runtime.fetchOrLoadConfig(
+            {
+              dx: target.device.dx,
+              dy: target.device.dy,
+              page: target.page,
+              element: target.element,
+              event: target.eventType,
+            },
+            resolve
+          );
+        }).then(() => {
+          const script = target.getConfig();
+          resolve(ConfigList.createFromActionString(script));
+        });
+      }
+    });
   }
 
   static createFromActionString(string) {
@@ -241,11 +253,13 @@ export class ConfigList extends Array {
         resolve("Event sent to grid.");
       };
       runtime.fetchOrLoadConfig(
-        target.device.dx,
-        target.device.dy,
-        target.page,
-        target.element,
-        target.eventType,
+        {
+          dx: target.device.dx,
+          dy: target.device.dy,
+          page: target.page,
+          element: target.element,
+          event: target.eventType,
+        },
         callback
       );
     });
@@ -255,6 +269,7 @@ export class ConfigList extends Array {
     //Parse actionString
     //TODO: do rawLuas format checking during parsing
 
+    let configList = [];
     // get rid of new line, enter
     actionString = actionString.replace(/[\n\r]+/g, "");
     // get rid of more than 2 spaces
@@ -265,7 +280,7 @@ export class ConfigList extends Array {
       actionString = actionString.split("<?lua")[1].split("?>")[0];
     }
     // split by meta comments
-    let configList = actionString.split(/(--\[\[@+\w+\]\])/);
+    configList = actionString.split(/(--\[\[@+\w+\]\])/);
 
     configList = configList.slice(1);
     for (var i = 0; i < configList.length; i += 2) {
@@ -343,10 +358,10 @@ export class ConfigTarget {
   static createFrom({ userInput }) {
     try {
       return new ConfigTarget({
-        device: { dx: userInput.brc.dx, dy: userInput.brc.dy },
-        page: userInput.event.pagenumber,
-        element: userInput.event.elementnumber,
-        eventType: userInput.event.eventtype,
+        device: { dx: userInput.dx, dy: userInput.dy },
+        page: userInput.pagenumber,
+        element: userInput.elementnumber,
+        eventType: userInput.eventtype,
       });
     } catch (e) {
       return undefined;
@@ -354,65 +369,47 @@ export class ConfigTarget {
   }
 
   getEvent() {
+    const element = this.getElement();
+    const event = element.events.find((e) => e.type == this.eventType);
+    return event;
+  }
+
+  getElement() {
+    const page = this.getPage();
+    const element = page.control_elements.find(
+      (e) => e.controlElementNumber == this.element
+    );
+    return element;
+  }
+
+  getPage() {
+    const device = this.getDevice();
+    const page = device.pages[this.page];
+    return page;
+  }
+
+  getDevice() {
     const rt = get(runtime);
     const device = rt.find(
       (e) => e.dx == this.device.dx && e.dy == this.device.dy
     );
-
-    if (typeof device === "undefined") {
-      return undefined;
-    }
-
-    const page = device.pages[this.page];
-
-    const element = page.control_elements.find(
-      (e) => e.controlElementNumber == this.element
-    );
-
-    const event = element.events.find((e) => e.event.value == this.eventType);
-
-    if (typeof event === "undefined") {
-      throw new UnknownEventException();
-    }
-
-    return event;
+    return device;
   }
 
-  getActionString() {
+  getConfig() {
     const event = this.getEvent();
-    if (typeof event === "undefined") {
-      return "";
-    }
-
-    const cfgstatus = event.cfgStatus;
-    if (
-      cfgstatus != "GRID_REPORT" &&
-      cfgstatus != "EDITOR_EXECUTE" &&
-      cfgstatus != "EDITOR_BACKGROUND"
-    ) {
-      const ui = get(user_input);
-      const { dx, dy, page, element, event } = {
-        dx: ui.brc.dx,
-        dy: ui.brc.dy,
-        page: ui.event.pagenumber,
-        element: ui.event.elementnumber,
-        event: ui.event.eventtype,
-      };
-      const callback = () => user_input.update((n) => n);
-      runtime.fetchOrLoadConfig(dx, dy, page, element, event, callback);
-    }
-
-    return event.config;
+    const res = event.config;
+    return res;
   }
 
   static getCurrent() {
     const ui = get(user_input);
     try {
       const currentTarget = new ConfigTarget({
-        device: { dx: ui.brc.dx, dy: ui.brc.dy },
-        page: ui.event.pagenumber,
-        element: ui.event.elementnumber,
-        eventType: ui.event.eventtype,
+        device: { dx: ui.dx, dy: ui.dy },
+        page: ui.pagenumber,
+        element: ui.elementnumber,
+        eventType: ui.eventtype,
       });
 
       return currentTarget;
@@ -428,41 +425,27 @@ export const configManager = create_configuration_manager();
 function create_configuration_manager() {
   const internal = writable(new ConfigList());
   const unsubscribeUserInput = user_input.subscribe((ui) => {
-    try {
-      const list = createConfigListFrom(ui);
-      setOverride(list);
-    } catch (e) {
-      console.warn("Error updating Configuration Manager from user input.");
-      console.warn(e);
-    }
+    createConfigListFrom(ui)
+      .then((list) => {
+        setOverride(list);
+      })
+      .catch((e) => {
+        console.error(e);
+        setOverride(new ConfigList());
+      });
   });
 
-  function createConfigListFrom(ui) {
-    const target = ConfigTarget.createFrom({ userInput: ui });
-    let list = new ConfigList();
-
-    if (typeof target === "undefined") {
-      return list;
-    }
-
-    try {
-      list = ConfigList.createFromTarget(target);
-    } catch (e) {
-      if (e instanceof UnknownEventException) {
-        const availableEvents = target.events.map((e) => e.event.value);
-        const closestEvent = Math.min(
-          ...availableEvents.map((e) => Number(e)).filter((e) => e > 0)
-        );
-        user_input.update((s) => {
-          s.event.eventtype = String(closestEvent);
-          return s;
+  async function createConfigListFrom(ui) {
+    return new Promise(async (resolve, reject) => {
+      const target = ConfigTarget.createFrom({ userInput: ui });
+      await ConfigList.createFromTarget(target)
+        .then((list) => {
+          resolve(list);
+        })
+        .catch((e) => {
+          reject(e);
         });
-      } else {
-        //Unknown error, display default
-        throw `Configuration: ${e}`;
-      }
-    }
-    return list;
+    });
   }
 
   function loadPreset({ x, y, element, preset }) {
@@ -480,7 +463,7 @@ function create_configuration_manager() {
       const { dx, dy, page, elementNumber } = {
         dx: x,
         dy: y,
-        page: ui.event.pagenumber,
+        page: ui.pagenumber,
         elementNumber: element,
       };
       runtime.fetch_element_configuration_from_grid(

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -44,9 +44,6 @@
     DragEvent,
   } from "../../_actions/move.action.js";
   import AddAction from "./components/AddAction.svelte";
-
-  import { init_config_block_library } from "../../../lib/_configs";
-  import { onMount } from "svelte";
   import AddActionButton from "./components/AddActionButton.svelte";
 
   //////////////////////////////////////////////////////////////////////////////
@@ -59,10 +56,6 @@
   let autoScroll;
   let dropIndex = undefined;
   let isSystemEventSelected = false;
-
-  onMount(() => {
-    init_config_block_library();
-  });
 
   //////////////////////////////////////////////////////////////////////////////
   /////////////////       REACTIVE STATEMENTS        ///////////////////////////

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -34,13 +34,13 @@
     }
   }
 
-  let selected = -1;
-  let elements = [{ title: "No Device", value: -1 }];
+  let selectedElementNumber = -1;
+  let options = [{ title: "No Device", value: -1 }];
 
-  $: handleSelectionChange(selected);
+  $: handleSelectedChange(selectedElementNumber);
 
-  function handleSelectionChange(value) {
-    if (value === -1 || typeof value === "undefined") {
+  function handleSelectedChange(elementNumber) {
+    if (elementNumber === -1 || typeof elementNumber === "undefined") {
       return;
     }
 
@@ -49,7 +49,7 @@
       dx: ui.dx,
       dy: ui.dy,
       pagenumber: ui.pagenumber,
-      elementnumber: value,
+      elementnumber: elementNumber,
       eventtype: ui.eventtype,
     });
   }
@@ -66,14 +66,14 @@
       (device) => device.dx === ui.dx && device.dy === ui.dy
     );
     if (typeof device === "undefined") {
-      elements = [{ title: "No Device", value: -1 }];
-      selected = -1;
+      options = [{ title: "No Device", value: -1 }];
+      selectedElementNumber = -1;
       return;
     }
     const control_elements = device.pages.find(
       (page) => page.pageNumber === ui.pagenumber
     )?.control_elements;
-    elements = control_elements.map((e) => {
+    options = control_elements.map((e) => {
       const stringName = getElementName(e.controlElementNumber);
       if (typeof stringName !== "undefined") {
         return { title: stringName, value: e.controlElementNumber };
@@ -91,7 +91,7 @@
         };
       }
     });
-    selected = ui.elementnumber;
+    selectedElementNumber = ui.elementnumber;
   }
 </script>
 
@@ -112,7 +112,7 @@
       />
     </div>
   </div>
-  {#key elements}
-    <MeltSelect bind:target={selected} options={elements} />
+  {#key options}
+    <MeltSelect bind:target={selectedElementNumber} {options} />
   {/key}
 </div>

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -42,16 +42,16 @@
   function handleSelectionChange(value) {
     if (value === -1 || typeof value === "undefined") {
       return;
-    } else {
-      const ui = $user_input;
-      user_input.set({
-        dx: ui.dx,
-        dy: ui.dy,
-        pagenumber: ui.pagenumber,
-        elementnumber: value,
-        eventtype: ui.eventtype,
-      });
     }
+
+    const ui = $user_input;
+    user_input.set({
+      dx: ui.dx,
+      dy: ui.dy,
+      pagenumber: ui.pagenumber,
+      elementnumber: value,
+      eventtype: ui.eventtype,
+    });
   }
 
   $: {

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -22,7 +22,7 @@
 
   function getElementName(value) {
     try {
-      const { dx, dy } = $user_input.brc;
+      const { dx, dy } = $user_input;
       const obj = $elementNameStore[dx][dy];
       if (obj[value] === "") {
         return undefined;
@@ -40,12 +40,16 @@
   $: handleSelectionChange(selected);
 
   function handleSelectionChange(value) {
-    if (value === -1) {
+    if (value === -1 || typeof value === "undefined") {
       return;
     } else {
-      user_input.update((ui) => {
-        ui.event.elementnumber = value;
-        return ui;
+      const ui = $user_input;
+      user_input.set({
+        dx: ui.dx,
+        dy: ui.dy,
+        pagenumber: ui.pagenumber,
+        elementnumber: value,
+        eventtype: ui.eventtype,
       });
     }
   }
@@ -59,7 +63,7 @@
   function renderElementList() {
     const ui = $user_input;
     const device = $runtime.find(
-      (device) => device.dx === ui.brc.dx && device.dy === ui.brc.dy
+      (device) => device.dx === ui.dx && device.dy === ui.dy
     );
     if (typeof device === "undefined") {
       elements = [{ title: "No Device", value: -1 }];
@@ -67,7 +71,7 @@
       return;
     }
     const control_elements = device.pages.find(
-      (page) => page.pageNumber === ui.event.pagenumber
+      (page) => page.pageNumber === ui.pagenumber
     )?.control_elements;
     elements = control_elements.map((e) => {
       const stringName = getElementName(e.controlElementNumber);
@@ -87,7 +91,7 @@
         };
       }
     });
-    selected = ui.event.elementnumber;
+    selected = ui.elementnumber;
   }
 </script>
 

--- a/src/renderer/main/panels/configuration/components/Pages.svelte
+++ b/src/renderer/main/panels/configuration/components/Pages.svelte
@@ -22,12 +22,10 @@
     }
   }
 
-  $: {
-    try {
-      selectedPage = $user_input.pagenumber;
-    } catch (error) {
-      console.log("Get page error", error);
-    }
+  $: handleUserInputChange($user_input);
+
+  function handleUserInputChange(ui) {
+    selectedPage = ui.pagenumber;
   }
 </script>
 

--- a/src/renderer/main/panels/configuration/components/Pages.svelte
+++ b/src/renderer/main/panels/configuration/components/Pages.svelte
@@ -24,7 +24,7 @@
 
   $: {
     try {
-      selectedPage = $user_input.event.pagenumber;
+      selectedPage = $user_input.pagenumber;
     } catch (error) {
       console.log("Get page error", error);
     }

--- a/src/renderer/main/panels/preferences/MeltSelect.svelte
+++ b/src/renderer/main/panels/preferences/MeltSelect.svelte
@@ -19,6 +19,12 @@
   });
 
   $: {
+    if ($selected) {
+      handleSelectionChange();
+    }
+  }
+
+  function handleSelectionChange() {
     if (typeof $selected === "undefined") {
       if (typeof target !== "undefined") {
         selected.set(() => {
@@ -30,13 +36,13 @@
             s.value = target;
             s.label = item.title;
             oldTarget = target;
+            console.log(s);
             return s;
           }
         });
       }
     } else {
       if (target !== oldTarget) {
-        //console.log("TEST 1", $selected.value);
         selected.update((s) => {
           const item = options.find((e) => {
             return e.value === target;
@@ -51,25 +57,10 @@
       }
 
       if (target !== $selected.value) {
-        //console.log("TEST 2", $selected.value);
         oldTarget = target = $selected.value;
       }
     }
   }
-
-  // $: {
-  //   //console.log("Target", target);
-  //   if (target !== oldTarget) {
-  //     $value[0] = target;
-  //     oldTarget = target;
-  //   }
-
-  //   if (target !== $value[0]) {
-  //     oldTarget = target = $value[0];
-  //   }
-  // }
-
-  // }
 </script>
 
 <div class="flex flex-col gap-1 {$$props.class}">

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { ConfigTarget } from "./../configuration/Configuration.store.js";
   import { onDestroy, onMount } from "svelte";
   import { v4 as uuidv4 } from "uuid";
   import { appSettings } from "../../../runtime/app-helper.store";
@@ -31,13 +32,13 @@
   $: {
     const ui = $user_input;
     let device = get(runtime).find(
-      (device) => device.dx == ui.brc.dx && device.dy == ui.brc.dy
+      (device) => device.dx == ui.dx && device.dy == ui.dy
     );
 
     if (typeof device !== "undefined") {
       selectedModule = device.id.substr(0, 4);
     }
-    selectedControlElementType = ui.event.elementtype;
+    selectedControlElementType = ui.elementtype;
   }
 
   function channelMessageWrapper(event, func) {
@@ -183,10 +184,8 @@
         };
 
         configs.forEach((d) => {
-          if (d.dx == li.brc.dx && d.dy == li.brc.dy) {
-            const page = d.pages.find(
-              (x) => x.pageNumber == li.event.pagenumber
-            );
+          if (d.dx == li.dx && d.dy == li.dy) {
+            const page = d.pages.find((x) => x.pageNumber == li.pagenumber);
 
             if (configType === "profile") {
               config.type = selectedModule;
@@ -195,7 +194,7 @@
                   controlElementNumber: cfg.controlElementNumber,
                   events: cfg.events.map((ev) => {
                     return {
-                      event: ev.event.value,
+                      event: ev.type,
                       config: ev.config,
                     };
                   }),
@@ -203,13 +202,17 @@
               });
             } else if (configType === "preset") {
               const element = page.control_elements.find(
-                (x) => x.controlElementNumber === li.event.elementnumber
+                (x) => x.controlElementNumber === li.elementnumber
               );
-              config.type = li.event.elementtype;
+
+              const current = ConfigTarget.createFrom({ userInput: li });
+              const type = current.getElement().controlElementType;
+
+              config.type = type;
               config.configs = {
                 events: element.events.map((ev) => {
                   return {
-                    event: ev.event.value,
+                    event: ev.type,
                     config: ev.config,
                   };
                 }),

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -167,7 +167,7 @@
           message: `Ready to save config!`,
         });
 
-        const li = get(user_input);
+        const ui = get(user_input);
 
         const configs = get(runtime);
 
@@ -189,8 +189,8 @@
         };
 
         configs.forEach((d) => {
-          if (d.dx == li.dx && d.dy == li.dy) {
-            const page = d.pages.find((x) => x.pageNumber == li.pagenumber);
+          if (d.dx == ui.dx && d.dy == ui.dy) {
+            const page = d.pages.find((x) => x.pageNumber == ui.pagenumber);
 
             if (configType === "profile") {
               config.type = selectedModule;
@@ -207,10 +207,10 @@
               });
             } else if (configType === "preset") {
               const element = page.control_elements.find(
-                (x) => x.controlElementNumber === li.elementnumber
+                (x) => x.controlElementNumber === ui.elementnumber
               );
 
-              const current = ConfigTarget.createFrom({ userInput: li });
+              const current = ConfigTarget.createFrom({ userInput: ui });
               const type = current.getElement().controlElementType;
 
               config.type = type;

--- a/src/renderer/main/user-interface/ActiveChanges.svelte
+++ b/src/renderer/main/user-interface/ActiveChanges.svelte
@@ -64,16 +64,9 @@
           logger.set({
             type: "success",
             mode: 0,
-            classname: "pagediscard",
-            message: `Discard complete!`,
+            classname: "pageclear",
+            message: `Page clear complete!`,
           });
-        });
-
-        logger.set({
-          type: "success",
-          mode: 0,
-          classname: "pageclear",
-          message: `Page clear complete!`,
         });
       })
       .catch((e) => {

--- a/src/renderer/protocol/grid-protocol.js
+++ b/src/renderer/protocol/grid-protocol.js
@@ -382,7 +382,7 @@ const utility_genId = () => {
 };
 
 // control element event assignment table.
-const CEEAT = {
+export const CEEAT = {
   undef: {
     desc: "UNDEFINED",
     value: "-1",

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -317,9 +317,9 @@ function create_user_input() {
 
   function module_destroy_handler(dx, dy) {
     // This is used to re-init local settings panel if a module is removed which values have been displayed
-    const li = get(internal);
+    const ui = get(internal);
 
-    if (dx == li.dx && dy == li.dy) {
+    if (dx == ui.dx && dy == ui.dy) {
       internal.set({ ...defaultValues });
     }
   }
@@ -528,7 +528,7 @@ function create_runtime() {
 
   function element_preset_load(x, y, element, preset) {
     return new Promise((resolve, reject) => {
-      const li = get(user_input);
+      const ui = get(user_input);
       let events = preset.configs.events;
       const callback = function () {
         resolve();
@@ -541,7 +541,7 @@ function create_runtime() {
       };
 
       events.forEach((ev, index) => {
-        const page = li.pagenumber;
+        const page = ui.pagenumber;
         const event = ev.event;
 
         _runtime.update((_runtime) => {
@@ -586,15 +586,15 @@ function create_runtime() {
         array.unshift(objectToMove);
       }
 
-      let li = structuredClone(get(user_input));
+      let ui = structuredClone(get(user_input));
       array.forEach((elem, elementIndex) => {
         elem.events.forEach((ev, eventIndex) => {
-          li.elementnumber = elem.controlElementNumber;
-          li.eventtype = ev.event;
+          ui.elementnumber = elem.controlElementNumber;
+          ui.eventtype = ev.event;
 
-          const page = li.pagenumber;
-          const element = li.elementnumber;
-          const event = li.eventtype;
+          const page = ui.pagenumber;
+          const element = ui.elementnumber;
+          const event = ui.eventtype;
 
           _runtime.update((_runtime) => {
             let dest = findUpdateDestEvent(
@@ -987,10 +987,10 @@ function create_runtime() {
       return;
     }
 
-    let li = get(user_input);
+    let ui = get(user_input);
 
     // only update pagenumber if it differs from the runtime pagenumber
-    if (li.pagenumber !== new_page_number) {
+    if (ui.pagenumber !== new_page_number) {
       // clean up the writebuffer if pagenumber changes!
       writeBuffer.clear();
 

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -649,8 +649,7 @@ function create_runtime() {
     page,
     element,
     event,
-    actionString,
-    status
+    actionString
   ) {
     // config
     _runtime.update((_runtime) => {

--- a/src/renderer/serialport/instructions.js
+++ b/src/renderer/serialport/instructions.js
@@ -358,108 +358,78 @@ const instructions = {
   },
 
   sendPageDiscardToGrid: () => {
-    logger.set({
-      type: "progress",
-      mode: 0,
-      classname: "pagediscard",
-      message: `Discarding configurations...`,
+    return new Promise((resolve, reject) => {
+      logger.set({
+        type: "progress",
+        mode: 0,
+        classname: "pagediscard",
+        message: `Discarding configurations...`,
+      });
+
+      let buffer_element = {
+        responseTimeout: 1000,
+        descr: {
+          brc_parameters: {
+            DX: -127,
+            DY: -127,
+          },
+          class_name: "PAGEDISCARD",
+          class_instr: "EXECUTE",
+          class_parameters: {},
+        },
+        responseRequired: true,
+        filter: {
+          PAGEDISCARD_ACKNOWLEDGE: {
+            LASTHEADER: null,
+          },
+          class_name: "PAGEDISCARD",
+          class_instr: "ACKNOWLEDGE",
+          class_parameters: {
+            LASTHEADER: null,
+          },
+        },
+        failCb: reject,
+        successCb: resolve,
+      };
+
+      writeBuffer.add_last(buffer_element);
     });
-
-    let buffer_element = {
-      responseTimeout: 1000,
-      descr: {
-        brc_parameters: {
-          DX: -127,
-          DY: -127,
-        },
-        class_name: "PAGEDISCARD",
-        class_instr: "EXECUTE",
-        class_parameters: {},
-      },
-      responseRequired: true,
-      filter: {
-        PAGEDISCARD_ACKNOWLEDGE: {
-          LASTHEADER: null,
-        },
-        class_name: "PAGEDISCARD",
-        class_instr: "ACKNOWLEDGE",
-        class_parameters: {
-          LASTHEADER: null,
-        },
-      },
-      failCb: function () {
-        logger.set({
-          type: "alert",
-          mode: 0,
-          classname: "pagediscard",
-          message: `Retry configuration discard...`,
-        });
-        //console.log('page discard execute - fail')
-      },
-      successCb: function () {
-        runtime.clear_page_configuration();
-        logger.set({
-          type: "success",
-          mode: 0,
-          classname: "pagediscard",
-          message: `Discard complete!`,
-        });
-        //console.log('page discard execute - success');
-      },
-    };
-
-    writeBuffer.add_last(buffer_element);
   },
 
   sendPageClearToGrid: () => {
-    logger.set({
-      type: "progress",
-      mode: 0,
-      classname: "pageclear",
-      message: `Clearing configurations from page...`,
+    return new Promise((resolve, reject) => {
+      logger.set({
+        type: "progress",
+        mode: 0,
+        classname: "pageclear",
+        message: `Clearing configurations from page...`,
+      });
+
+      let buffer_element = {
+        responseTimeout: 2000,
+        descr: {
+          brc_parameters: {
+            DX: -127,
+            DY: -127,
+          },
+          class_name: "PAGECLEAR",
+          class_instr: "EXECUTE",
+          class_parameters: {},
+        },
+        responseRequired: true,
+        filter: {
+          class_name: "PAGECLEAR",
+          class_instr: "ACKNOWLEDGE",
+          class_parameters: {
+            LASTHEADER: null,
+          },
+        },
+        failCb: reject,
+        successCb: resolve,
+      };
+
+      writeBuffer.add_first(buffer_element);
     });
-
-    let buffer_element = {
-      responseTimeout: 2000,
-      descr: {
-        brc_parameters: {
-          DX: -127,
-          DY: -127,
-        },
-        class_name: "PAGECLEAR",
-        class_instr: "EXECUTE",
-        class_parameters: {},
-      },
-      responseRequired: true,
-      filter: {
-        class_name: "PAGECLEAR",
-        class_instr: "ACKNOWLEDGE",
-        class_parameters: {
-          LASTHEADER: null,
-        },
-      },
-      failCb: function () {
-        logger.set({
-          type: "alert",
-          mode: 0,
-          classname: "pageclear",
-          message: `Retry clear page...`,
-        });
-        //console.log('page clear execute - fail')
-      },
-      successCb: function () {
-        runtime.clear_page_configuration();
-        logger.set({
-          type: "success",
-          mode: 0,
-          classname: "pageclear",
-          message: `Page clear complete!`,
-        });
-        //console.log('page clear execute - success')
-      },
-    };
-
-    writeBuffer.add_first(buffer_element);
   },
 };
 

--- a/src/renderer/serialport/instructions.js
+++ b/src/renderer/serialport/instructions.js
@@ -88,8 +88,7 @@ const instructions = {
           page,
           element,
           event,
-          actionstring,
-          "GRID_REPORT"
+          actionstring
         );
 
         if (callback) {

--- a/src/renderer/serialport/message-stream.store.js
+++ b/src/renderer/serialport/message-stream.store.js
@@ -157,17 +157,18 @@ function createMessageStream() {
         class_descr.class_name === "PAGEACTIVE" &&
         class_descr.class_instr === "REPORT"
       ) {
+        const ui = get(user_input);
         //After page change set user_input so it does not get cleared from writebuffer
-        if (get(user_input).event === undefined) return;
+        if (ui.event === undefined) return; //TODO: check
 
         //return;
-        if (
-          get(user_input).event.pagenumber !==
-          class_descr.class_parameters.PAGENUMBER
-        ) {
-          user_input.update((s) => {
-            s.event.pagenumber = class_descr.class_parameters.PAGENUMBER;
-            return s;
+        if (ui.pagenumber !== class_descr.class_parameters.PAGENUMBER) {
+          user_input.set({
+            dx: ui.dx,
+            dy: ui.dy,
+            pagenumber: class_descr.class_parameters.PAGENUMBER,
+            elementnumber: ui.elementnumber,
+            eventtype: ui.eventtype,
           });
         }
       }


### PR DESCRIPTION
Closes #538 

The cleanup affected almost if not all functionality of grid editor.

**These changes (not exclusively) include the following:**

- Additional various fixes were included when user_input was reworked into a clean, mostly readonly object.
- Additional functional reworks were included when the necessary user_input "pinging" (e.g.: user_input.update((n) => n)) was reduced into a new Promise based functionality.
- Parts of unnecessary complex code were removed, and/or was recreated in a semantically equivalent way. 

**Consequences:**

The base functionalities of editor are working as expected, the editor seems to be working as expected. 
However, since the risk of introduced bugs are high, thorough testing might be necessary before release.