### PR TITLE
ActionBlock information is cleaned up and is made to be typed

### DIFF
--- a/src/renderer/config-blocks/ActionBlockInformation.ts
+++ b/src/renderer/config-blocks/ActionBlockInformation.ts
@@ -1,0 +1,43 @@
+type HexColor = `#${string}`;
+
+export interface LuaScript {
+  short: string;
+  script: string;
+}
+
+type EnsureNonOptional<T> = {
+  [K in keyof T]: T[K] extends infer U | undefined ? U : T[K];
+};
+
+export type ActionBlockInformation = EnsureNonOptional<Information>;
+
+interface Information {
+  short: string;
+  name: string;
+  rendering: "modifier" | "standard";
+  category:
+    | "variables"
+    | "led"
+    | "midi"
+    | "keyboard"
+    | "mouse"
+    | "element settings"
+    | "condition"
+    | "loop"
+    | "special"
+    | "code"
+    | "timer"
+    | null;
+  displayName: string;
+  defaultLua: string;
+  icon: string;
+  color: HexColor;
+  blockIcon: string;
+  selectable: boolean;
+  movable: boolean;
+  type: "composite_part" | "composite_open" | "composite_close" | "single";
+  toggleable: boolean;
+  hideIcon: boolean;
+  rounding?: "top" | "bottom";
+  compositeLua?: LuaScript[];
+}

--- a/src/renderer/config-blocks/ButtonPressRelease_Else.svelte
+++ b/src/renderer/config-blocks/ButtonPressRelease_Else.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "bprel",
     name: "ButtonPressRelease_Else",
     rendering: "modifier",
     category: null,
-    desc: "Release",
-    blockTitle: "Release",
+    displayName: "Release",
     defaultLua: "else",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 445 327" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/ButtonPressRelease_End.svelte
+++ b/src/renderer/config-blocks/ButtonPressRelease_End.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "bpre",
     name: "ButtonPressRelease_End",
     rendering: "modifier",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     rounding: "bottom",
     defaultLua: "end",
     icon: `

--- a/src/renderer/config-blocks/ButtonPressRelease_If.svelte
+++ b/src/renderer/config-blocks/ButtonPressRelease_If.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
+
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "bpr",
     name: "ButtonPressRelease_If",
     rendering: "modifier",
     rounding: "top",
     category: "special",
-    eventtype: [3], // 2: encoder
-    desc: "Press/Release",
-    blockTitle: "Press",
+    displayName: "Press",
     defaultLua: "if self:bst()>0 then",
     compositeLua: [
       { short: "bprel", script: "else" },
@@ -105,7 +105,7 @@
   import stringManipulation from "../main/user-interface/_string-operations";
   import { parenthesis } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   export let access_tree;

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "cb",
     name: "CodeBlock",
     rendering: "standard",
     category: "code",
-    desc: "Code Block",
-    blockTitle: "Code Block",
+    displayName: "Code Block",
     color: "#887880",
     defaultLua: 'print("hello")',
     icon: `

--- a/src/renderer/config-blocks/Comment.svelte
+++ b/src/renderer/config-blocks/Comment.svelte
@@ -1,17 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "c",
     name: "Comment",
     rendering: "standard",
-    toggleable: false,
     category: "code",
-    desc: "Comment Block",
-    blockTitle: "Comment Block",
+    displayName: "Comment Block",
     defaultLua: "--[[This Is A Comment]]",
     icon: `
     <span class="block w-full text-black text-center italic font-gt-pressura">--</span>
@@ -33,7 +32,7 @@
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/Condition_Else.svelte
+++ b/src/renderer/config-blocks/Condition_Else.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "el",
     name: "Condition_Else",
     rendering: "modifier",
     category: "condition",
-    desc: "Else",
-    blockTitle: "Else",
+    displayName: "Else",
     defaultLua: "else",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 277 277" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -38,5 +38,5 @@
 </script>
 
 <else-block class="{$$props.class} text-white pointer-events-auto">
-  {information.blockTitle}
+  {information.displayName}
 </else-block>

--- a/src/renderer/config-blocks/Condition_ElseIf.svelte
+++ b/src/renderer/config-blocks/Condition_ElseIf.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import ConditionElseIfFace from "./headers/ConditionElseIfFace.svelte";
   export const header = ConditionElseIfFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "ei",
     name: "Condition_ElseIf",
     rendering: "modifier",
     category: "condition",
-    desc: "Else if",
-    blockTitle: "Else if",
+    displayName: "Else if",
     defaultLua: "elseif  then",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 277 277" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/Condition_End.svelte
+++ b/src/renderer/config-blocks/Condition_End.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "en",
     name: "Condition_End",
     rendering: "modifier",
     rounding: "bottom",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     defaultLua: "end",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 277 277" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -41,5 +41,5 @@
 </script>
 
 <endif-block class="{$$props.class} text-white pointer-events-auto">
-  {information.blockTitle}
+  {information.displayName}
 </endif-block>

--- a/src/renderer/config-blocks/Condition_If.svelte
+++ b/src/renderer/config-blocks/Condition_If.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import ConditionIfFace from "./headers/ConditionIfFace.svelte";
   export const header = ConditionIfFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "if",
     name: "Condition_If",
     rendering: "modifier",
     rounding: "top",
     category: "condition",
-    desc: "If",
-    blockTitle: "If",
+    displayName: "If",
     defaultLua: "if  then",
     compositeLua: [{ short: "en", script: "end" }],
     icon: `

--- a/src/renderer/config-blocks/ElementName.svelte
+++ b/src/renderer/config-blocks/ElementName.svelte
@@ -1,17 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "sn",
     name: "ElementName",
-    rendering: "standard", //'hidden'
-    toggleable: false,
+    rendering: "standard",
     category: "code",
-    desc: "Element Name",
-    blockTitle: "Element Name",
+    displayName: "Element Name",
     defaultLua: "self.sn=''",
     icon: `
     <span class="block w-full text-black text-center italic font-gt-pressura">N</span>
@@ -33,7 +32,7 @@
   import AtomicInput from "../main/user-interface/AtomicInput.svelte";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/EncoderLeftRight_Else.svelte
+++ b/src/renderer/config-blocks/EncoderLeftRight_Else.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "elrel",
     name: "EncoderLeftRight_Else",
     rendering: "modifier",
     category: null,
-    desc: "Rotate Right",
-    blockTitle: "Rotate Right",
+    displayName: "Rotate Right",
     defaultLua: "else",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 445 338" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/EncoderLeftRight_End.svelte
+++ b/src/renderer/config-blocks/EncoderLeftRight_End.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "elre",
     name: "EncoderLeftRight_End",
     rendering: "modifier",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     rounding: "bottom",
     defaultLua: "end",
     icon: `

--- a/src/renderer/config-blocks/EncoderLeftRight_If.svelte
+++ b/src/renderer/config-blocks/EncoderLeftRight_If.svelte
@@ -1,18 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "elr",
     name: "EncoderLeftRight_If",
     rendering: "modifier",
     rounding: "top",
     category: "special",
-    eventtype: [2], // 2: encoder
-    desc: "Left/Right Rotate",
-    blockTitle: "Rotate Left",
+    displayName: "Rotate Left",
     defaultLua: "if self:est()<64 then",
     compositeLua: [
       { short: "elrel", script: "else" },
@@ -62,7 +61,7 @@
   import stringManipulation from "../main/user-interface/_string-operations";
   import { parenthesis } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   export let access_tree;

--- a/src/renderer/config-blocks/EncoderPushRotLeftRight_Else.svelte
+++ b/src/renderer/config-blocks/EncoderPushRotLeftRight_Else.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprlrel",
     name: "EncoderPushRotLeftRight_Else",
     rendering: "modifier",
     category: null,
-    desc: "Just Rotate Right",
-    blockTitle: "Just Rotate Right",
+    displayName: "Just Rotate Right",
     defaultLua: "else",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 445 338" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/EncoderPushRotLeftRight_ElseIf1.svelte
+++ b/src/renderer/config-blocks/EncoderPushRotLeftRight_ElseIf1.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprlrei1",
     name: "Condition_ElseIf",
     rendering: "modifier",
     category: null,
-    desc: "PRLR Else IF",
-    blockTitle: "Push & Rotate Right",
+    displayName: "Push & Rotate Right",
     defaultLua: "elseif (self:bst()>0 and self:est()>63) then",
     icon: undefined,
     blockIcon: `

--- a/src/renderer/config-blocks/EncoderPushRotLeftRight_ElseIf2.svelte
+++ b/src/renderer/config-blocks/EncoderPushRotLeftRight_ElseIf2.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprlrei2",
     name: "Condition_ElseIf",
     rendering: "modifier",
     category: null,
-    desc: "PRLR Else IF",
-    blockTitle: "Just Rotate Left",
+    displayName: "Just Rotate Left",
     defaultLua: "elseif (self:bst()==0 and self:est()<64) then",
     icon: undefined,
     blockIcon: `<svg width="100%" height="100%" viewBox="0 0 445 338" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/EncoderPushRotLeftRight_End.svelte
+++ b/src/renderer/config-blocks/EncoderPushRotLeftRight_End.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprlre",
     name: "EncoderPushRotLeftRight_End",
     rendering: "modifier",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     rounding: "bottom",
     defaultLua: "end",
     icon: `

--- a/src/renderer/config-blocks/EncoderPushRotLeftRight_If.svelte
+++ b/src/renderer/config-blocks/EncoderPushRotLeftRight_If.svelte
@@ -1,18 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprlr",
     name: "EncoderPushRotLeftRight_If",
     rendering: "modifier",
     rounding: "top",
     category: "special",
-    eventtype: [2], // 2: encoder
-    desc: "Push & Rotate L R",
-    blockTitle: "Push & Rotate Left",
+    displayName: "Push & Rotate Left",
     defaultLua: "if (self:bst()>0 and self:est()<64) then",
     compositeLua: [
       {

--- a/src/renderer/config-blocks/EncoderPushRot_Else.svelte
+++ b/src/renderer/config-blocks/EncoderPushRot_Else.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "eprel",
     name: "EncoderPushRot_Else",
     rendering: "modifier",
     category: null,
-    desc: "Just Rotate",
-    blockTitle: "Just Rotate",
+    displayName: "Just Rotate",
     defaultLua: "else",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 445 327" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/EncoderPushRot_End.svelte
+++ b/src/renderer/config-blocks/EncoderPushRot_End.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "epre",
     name: "EncoderPushRot_End",
     rendering: "modifier",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     rounding: "bottom",
     defaultLua: "end",
     icon: `

--- a/src/renderer/config-blocks/EncoderPushRot_If.svelte
+++ b/src/renderer/config-blocks/EncoderPushRot_If.svelte
@@ -1,18 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "epr",
     name: "EncoderPushRot_If",
     rendering: "modifier",
     rounding: "top",
     category: "special",
-    eventtype: [2], // 2: encoder
-    desc: "Push & Rotate",
-    blockTitle: "Push & Rotate",
+    displayName: "Push & Rotate",
     defaultLua: "if self:bst()>0 then",
     compositeLua: [
       { short: "eprel", script: "else" },
@@ -44,7 +43,7 @@
   import stringManipulation from "../main/user-interface/_string-operations";
   import { parenthesis } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   export let access_tree;

--- a/src/renderer/config-blocks/For_Loop.svelte
+++ b/src/renderer/config-blocks/For_Loop.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import ForLoopHeader from "./headers/ForLoopHeader.svelte";
   export const header = ForLoopHeader;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "for",
     name: "For_Loop",
     rendering: "modifier",
     rounding: "top",
     category: "loop",
-    desc: "Repeater Loop",
-    blockTitle: "Repeater Loop",
+    displayName: "Repeater Loop",
     defaultLua: "for i=1,10,1 do",
     compositeLua: [{ short: "enl", script: "end" }],
     icon: `<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="3.32 5.32 17.37 16.37"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M8 18H7C5.34315 18 4 16.6569 4 15V9C4 7.34315 5.34315 6 7 6H17C18.6569 6 20 7.34315 20 9V15C20 16.6569 18.6569 18 17 18H12M12 18L15 15M12 18L15 21" stroke="#000000" stroke-width="1.3679999999999999" stroke-linecap="round" stroke-linejoin="round"></path> </g></svg>`,

--- a/src/renderer/config-blocks/LedAnimationStart.svelte
+++ b/src/renderer/config-blocks/LedAnimationStart.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "glat",
     name: "LedAnimationStart",
     rendering: "standard",
     category: "led",
-    desc: "Start Animation",
-    blockTitle: "Start Animation",
+    displayName: "Start Animation",
     color: "#726E60",
     defaultLua: "glpfs(num,1,val,1,1)",
     icon: `

--- a/src/renderer/config-blocks/LedAnimationStop.svelte
+++ b/src/renderer/config-blocks/LedAnimationStop.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "glap",
     name: "LedAnimationStop",
     rendering: "standard",
     category: "led",
-    desc: "Stop Animation",
-    blockTitle: "Stop Animation",
+    displayName: "Stop Animation",
     color: "#726E60",
     defaultLua: "glpfs(num,1,0,0,0)",
     icon: `

--- a/src/renderer/config-blocks/LedColor.svelte
+++ b/src/renderer/config-blocks/LedColor.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "glc",
     name: "LedColor",
     category: "led",
     rendering: "standard",
     color: "#726E60",
-    desc: "Color",
-    blockTitle: "Color",
+    displayName: "Color",
     defaultLua: "glc(,,,,)",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 404 404" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/LedPhase.svelte
+++ b/src/renderer/config-blocks/LedPhase.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "glp",
     name: "LedPhase",
     rendering: "standard",
     category: "led",
-    desc: "Intensity",
-    blockTitle: "Intensity",
+    displayName: "Intensity",
     color: "#726E60",
     defaultLua: "glp(,,)",
     icon: `

--- a/src/renderer/config-blocks/Lookup.svelte
+++ b/src/renderer/config-blocks/Lookup.svelte
@@ -1,15 +1,15 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "glut",
     name: "Lookup",
     rendering: "standard",
     category: "variables",
-    desc: "Lookup",
-    blockTitle: "Lookup",
+    displayName: "Lookup",
     color: "#78BC61",
     defaultLua: "glut(param1,36,0,37,1)",
     icon: `<svg width="100%" height="100%" viewBox="0 0 163 212" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -44,7 +44,7 @@
   import { Validator } from "./_validators";
   import { Script } from "./_script_parsers.js";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/Loop_End.svelte
+++ b/src/renderer/config-blocks/Loop_End.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import CompositeFace from "./headers/CompositeFace.svelte";
   export const header = CompositeFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "enl",
     name: "Loop_End",
     rendering: "modifier",
     rounding: "bottom",
     category: null,
-    desc: "End",
-    blockTitle: "End",
+    displayName: "End",
     defaultLua: "end",
     icon: `
     <svg width="100%" height="100%" viewBox="0 0 277 277" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/Macro.svelte
+++ b/src/renderer/config-blocks/Macro.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gks",
     name: "Macro",
     rendering: "standard",
     category: "keyboard",
     color: "#9D95AD",
-    desc: "Keyboard",
-    blockTitle: "Keyboard",
+    displayName: "Keyboard",
     defaultLua: "gks()",
     icon: `
       <svg width="100%" height="100%" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/renderer/config-blocks/Midi.svelte
+++ b/src/renderer/config-blocks/Midi.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import MidiFace from "./headers/MidiFace.svelte";
   export const header = MidiFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gms",
     name: "Midi",
     rendering: "standard",
     category: "midi",
-    desc: "MIDI",
-    blockTitle: "MIDI",
+    displayName: "MIDI",
     color: "#DA4167",
     defaultLua: "gms(0,176,num,val)",
     icon: `
@@ -53,7 +53,7 @@
 
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   import SendFeedback from "../main/user-interface/SendFeedback.svelte";

--- a/src/renderer/config-blocks/MidiFourteenBit.svelte
+++ b/src/renderer/config-blocks/MidiFourteenBit.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import MidiFourteenBitFace from "./headers/MidiFourteenBitFace.svelte";
   export const header = MidiFourteenBitFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gmsh",
     name: "MidiFourteenBit",
     rendering: "standard",
     category: "midi",
-    desc: "MIDI 14",
-    blockTitle: "MIDI 14",
+    displayName: "MIDI 14",
     color: "#DA4167",
     defaultLua: "gms(0,176,0,val//128) gms(0,176,32,val%128)",
     icon: `
@@ -52,7 +52,7 @@
 
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   import SendFeedback from "../main/user-interface/SendFeedback.svelte";

--- a/src/renderer/config-blocks/MidiSysEx.svelte
+++ b/src/renderer/config-blocks/MidiSysEx.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import MidiSysExFace from "./headers/MidiSysExFace.svelte";
   export const header = MidiSysExFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gmss",
     name: "MidiSysEx",
     rendering: "standard",
     category: "midi",
-    desc: "MIDI SysEX",
-    blockTitle: "MIDI SysEX",
+    displayName: "MIDI SysEX",
     color: "#DA4167",
     defaultLua: "gmss(0xF0, 0x41, 0x10, val, 0xF7)",
     icon: `
@@ -50,7 +50,7 @@
   import TabButton from "../main/user-interface/TabButton.svelte";
   import SendFeedback from "../main/user-interface/SendFeedback.svelte";
 
-  export let config = "";
+  export let config;
   export let index;
 
   let loaded = false;

--- a/src/renderer/config-blocks/MouseButton.svelte
+++ b/src/renderer/config-blocks/MouseButton.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gmbs",
     name: "MouseButton",
     rendering: "standard",
     category: "mouse",
-    desc: "Button",
-    blockTitle: "Button",
+    displayName: "Button",
     defaultLua: "gmbs(,)",
     color: "#9C92A4",
     icon: `
@@ -39,7 +39,7 @@
   import { Script } from "./_script_parsers.js";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/MouseMove.svelte
+++ b/src/renderer/config-blocks/MouseMove.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gmms",
     name: "MouseMove",
     rendering: "standard",
     category: "mouse",
-    desc: "Move",
-    blockTitle: "Move",
+    displayName: "Move",
     defaultLua: "gmms(,)",
     color: "#9C92A4",
     icon: `

--- a/src/renderer/config-blocks/RawCode.svelte
+++ b/src/renderer/config-blocks/RawCode.svelte
@@ -1,15 +1,15 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   export const header = undefined;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "raw",
     name: "CodeBlock",
     rendering: "standard",
     category: null,
-    desc: "RAW code",
-    blockTitle: "RAW code",
+    displayName: "RAW code",
     color: "#f0f5f7",
     defaultLua: undefined,
     icon: undefined,

--- a/src/renderer/config-blocks/SettingsButton.svelte
+++ b/src/renderer/config-blocks/SettingsButton.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "sbc",
     name: "SettingsButton",
     rendering: "standard",
     category: "element settings",
-    desc: "Button Mode",
-    blockTitle: "Button Mode",
+    displayName: "Button Mode",
     color: "#5F416D",
     defaultLua: "self:bmo(0)",
     icon: `<span class="block w-full text-center italic font-gt-pressura">BC</span>`,
@@ -30,7 +30,7 @@
   import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/SettingsEncoder.svelte
+++ b/src/renderer/config-blocks/SettingsEncoder.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "sec",
     name: "SettingsEncoder",
     rendering: "standard",
     category: "element settings",
     color: "#5F416D",
-    desc: "Encoder Mode",
-    blockTitle: "Encoder Mode",
+    displayName: "Encoder Mode",
     defaultLua: "self:emo(0) self:ev0(50)",
     icon: `<span class="block w-full text-center italic font-gt-pressura">EC</span>`,
     blockIcon: `<span class="block w-full text-center italic font-gt-pressura">EC</span>`,
@@ -30,7 +30,7 @@
   import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/SettingsPotmeter.svelte
+++ b/src/renderer/config-blocks/SettingsPotmeter.svelte
@@ -1,17 +1,17 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "spc",
     name: "SettingsPotmeter",
     rendering: "standard",
     category: "element settings",
     color: "#5F416D",
-    desc: "Potmeter Mode",
-    blockTitle: "Potmeter Mode",
+    displayName: "Potmeter Mode",
     defaultLua: "self:pmo(7) self:pma(127)",
     icon: `<span class="block w-full text-center italic font-gt-pressura">PC</span>`,
     blockIcon: `<span class="block w-full text-center italic font-gt-pressura">PC</span>`,
@@ -30,7 +30,7 @@
   import { configManager } from "../main/panels/configuration/Configuration.store";
   import { Validator } from "./_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   const dispatch = createEventDispatcher();

--- a/src/renderer/config-blocks/TimerSource.svelte
+++ b/src/renderer/config-blocks/TimerSource.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gts",
     name: "TimerSource",
     category: "timer",
     rendering: "standard",
-    desc: "Clock Source",
-    blockTitle: "Clock Source",
+    displayName: "Clock Source",
     color: "#95638D",
     defaultLua: "gts(,)",
     icon: `

--- a/src/renderer/config-blocks/TimerStart.svelte
+++ b/src/renderer/config-blocks/TimerStart.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gtt",
     name: "TimerStart",
     category: "timer",
     rendering: "standard",
-    desc: "Start",
-    blockTitle: "Start",
+    displayName: "Start",
     color: "#95638D",
     defaultLua: "gtt(,)",
     icon: `

--- a/src/renderer/config-blocks/TimerStop.svelte
+++ b/src/renderer/config-blocks/TimerStop.svelte
@@ -1,16 +1,16 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
   // config descriptor parameters
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "gtp",
     name: "TimerStop",
     rendering: "standard",
     category: "timer",
-    desc: "Stop",
-    blockTitle: "Stop",
+    displayName: "Stop",
     color: "#95638D",
     defaultLua: "gtp()",
     icon: `

--- a/src/renderer/config-blocks/VarGlobal.svelte
+++ b/src/renderer/config-blocks/VarGlobal.svelte
@@ -1,15 +1,15 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "g",
     name: "VarGlobal",
     rendering: "standard",
     category: "variables",
-    desc: "Global",
-    blockTitle: "Global",
+    displayName: "Global",
     defaultLua: "test = self:ind()",
     color: "#78BC61",
     icon: `<span class="block w-full text-black text-center italic font-gt-pressura">G</span>`,
@@ -36,7 +36,7 @@
   import { find_forbidden_identifiers } from "../runtime/monaco-helper";
   let error_messsage = "";
 
-  export let config = "";
+  export let config;
   export let index;
   export let access_tree;
 

--- a/src/renderer/config-blocks/VarLocals.svelte
+++ b/src/renderer/config-blocks/VarLocals.svelte
@@ -1,15 +1,15 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "l",
     name: "VarLocals",
     rendering: "standard",
     category: "variables",
-    desc: "Locals",
-    blockTitle: "Locals",
+    displayName: "Locals",
     defaultLua: "local num = self:ind()",
     color: "#78BC61",
     icon: `<span class="block w-full text-black text-center italic font-gt-pressura">L</span>`,
@@ -36,7 +36,7 @@
   import { find_forbidden_identifiers } from "../runtime/monaco-helper";
   let error_messsage = "";
 
-  export let config = "";
+  export let config;
   export let index;
   export let access_tree;
 
@@ -232,7 +232,7 @@
       on:click={() => {
         sendData();
       }}
-      disabled={!commitState && parenthesisError && variableNameError}
+      disabled={Boolean(!commitState && parenthesisError && variableNameError)}
       class="{commitState && !parenthesisError && !variableNameError
         ? 'opacity-100'
         : 'opacity-50 pointer-events-none'} bg-commit hover:bg-commit-saturate-20 text-white rounded px-2 py-0.5 text-sm focus:outline-none"

--- a/src/renderer/config-blocks/VarSelf.svelte
+++ b/src/renderer/config-blocks/VarSelf.svelte
@@ -1,15 +1,15 @@
-<script context="module">
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
 
-  export const information = {
+  export const information: ActionBlockInformation = {
     short: "s",
     name: "VarSelf",
     rendering: "standard",
     category: "variables",
-    desc: "Self",
-    blockTitle: "Self",
+    displayName: "Self",
     defaultLua: "",
     color: "#78BC61",
     icon: `<span class="block w-full text-black text-center italic font-gt-pressura">S</span>`,
@@ -36,7 +36,7 @@
   import { find_forbidden_identifiers } from "../runtime/monaco-helper";
   let error_messsage = "";
 
-  export let config = "";
+  export let config;
   export let index;
   export let access_tree;
 

--- a/src/renderer/config-blocks/headers/CompositeFace.svelte
+++ b/src/renderer/config-blocks/headers/CompositeFace.svelte
@@ -20,5 +20,5 @@
   class:rounded-br-xl={config.information.rounding == "bottom"}
   on:click={handleClick}
 >
-  <span>{config.information.blockTitle}</span>
+  <span>{config.information.displayName}</span>
 </div>

--- a/src/renderer/config-blocks/headers/ConditionElseIfFace.svelte
+++ b/src/renderer/config-blocks/headers/ConditionElseIfFace.svelte
@@ -5,7 +5,7 @@
 
   const dispatch = createEventDispatcher();
 
-  export let config = "";
+  export let config;
   export let index;
 
   export let access_tree;

--- a/src/renderer/config-blocks/headers/ConditionIfFace.svelte
+++ b/src/renderer/config-blocks/headers/ConditionIfFace.svelte
@@ -3,7 +3,7 @@
   import stringManipulation from "../../main/user-interface/_string-operations";
   import { parenthesis } from "../_validators";
 
-  export let config = "";
+  export let config;
   export let index;
 
   export let access_tree;

--- a/src/renderer/config-blocks/headers/MidiFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiFace.svelte
@@ -36,7 +36,7 @@
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">
     <span class="mr-2 w-fit whitespace-nowrap"
-      >{config.information.blockTitle}</span
+      >{config.information.displayName}</span
     >
     <div class="bg-primary p-1 my-auto rounded truncate">
       <span class="whitespace-nowrap text-white text-opacity-60">

--- a/src/renderer/config-blocks/headers/MidiFourteenBitFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiFourteenBitFace.svelte
@@ -69,7 +69,7 @@
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">
     <span class="mr-2 w-fit whitespace-nowrap"
-      >{config.information.blockTitle}</span
+      >{config.information.displayName}</span
     >
     <div class="bg-primary p-1 my-auto rounded truncate">
       <span class="whitespace-nowrap text-white text-opacity-60">

--- a/src/renderer/config-blocks/headers/MidiSysExFace.svelte
+++ b/src/renderer/config-blocks/headers/MidiSysExFace.svelte
@@ -26,7 +26,7 @@
 >
   <div class="grid grid-cols-[auto_1fr] items-center h-full w-full">
     <span class="mr-2 w-fit whitespace-nowrap"
-      >{config.information.blockTitle}</span
+      >{config.information.displayName}</span
     >
     <div class="bg-primary p-1 my-auto rounded truncate">
       <span class="whitespace-nowrap text-white text-opacity-60">

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -20,5 +20,5 @@
     : ''}"
   on:click={handleClick}
 >
-  <span>{config.information.blockTitle}</span>
+  <span>{config.information.displayName}</span>
 </div>

--- a/src/renderer/main/panels/configuration/components/ActionPicker.svelte
+++ b/src/renderer/main/panels/configuration/components/ActionPicker.svelte
@@ -277,7 +277,7 @@
       event: "Config Action",
       payload: {
         click: "Add Action",
-        actionBlock: component.information.desc,
+        actionBlock: component.information.name,
       },
       mandatory: false,
     });
@@ -344,7 +344,7 @@
                   <div
                     class="py-0.5 ml-1 px-1 bg-secondary rounded bg-opacity-25"
                   >
-                    {component.information.desc}
+                    {component.information.displayName}
                   </div>
                 </div>
               {/each}


### PR DESCRIPTION
Closes #460 

- ActionBlocks information field is now throwing error when adding not defined properties to it. 
- The property list is defined in typescript in a separate file.
- When a non-optional property is omitted an error is thrown.
- All these thrown errors are only visible during editing the code in VS Code. 