### PR TITLE
Fix package manager freeze if IO error happens during download

### DIFF
--- a/src/electron/plugin/pluginManager.ts
+++ b/src/electron/plugin/pluginManager.ts
@@ -218,7 +218,7 @@ async function downloadPlugin(pluginName: string) {
       try {
         fileStream.on("error", (err) => {
           reject(err);
-        })
+        });
         fileStream.on("finish", () => {
           fileStream.close();
           resolve(null);
@@ -270,7 +270,7 @@ async function getInstalledPlugins(): Promise<
     pluginPreferenceHtml?: string;
   }[]
 > {
-  if (!fs.existsSync(pluginFolder)){
+  if (!fs.existsSync(pluginFolder)) {
     return [];
   }
   const readdir = util.promisify(fs.readdir);


### PR DESCRIPTION
The package manager process froze if any error happened during the download of the archive. This PR aims to fix this error.