### PR TITLE
🚩PR: Fixed runtime error for dropdown select list

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -174,10 +174,8 @@ export class ConfigList extends Array {
 
   static updateIndentation(list) {
     let indentation = 0;
-    console.log(list);
     for (let i = 0; i < list.length; i++) {
       let config = list[i];
-      console.log(config);
       if (config.information.type === "composite_open") {
         config.indentation = indentation++;
       } else if (config.information.type === "composite_close") {

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -57,9 +57,10 @@
   let [dx, dy] = [undefined, undefined];
   $: {
     if ($user_input || $elementNameStore) {
-      if (dx !== $user_input.dx || dy !== $user_input.dy) {
-        dx = $user_input.dx;
-        dy = $user_input.dy;
+      const noDevice = $user_input.elementnumber === -1;
+      if (dx !== $user_input.dx || dy !== $user_input.dy || noDevice) {
+        dx = noDevice ? undefined : $user_input.dx;
+        dy = noDevice ? undefined : $user_input.dy;
         renderElementList();
       }
     }

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -54,9 +54,14 @@
     });
   }
 
+  let [dx, dy] = [undefined, undefined];
   $: {
     if ($user_input || $elementNameStore) {
-      renderElementList();
+      if (dx !== $user_input.dx || dy !== $user_input.dy) {
+        dx = $user_input.dx;
+        dy = $user_input.dy;
+        renderElementList();
+      }
     }
   }
 

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -84,8 +84,6 @@
       lastOpenedActionblocksRemove(config.short);
     }
   }
-
-  $: console.log(config.indentation);
 </script>
 
 <wrapper

--- a/src/renderer/main/panels/preferences/MeltSelect.svelte
+++ b/src/renderer/main/panels/preferences/MeltSelect.svelte
@@ -33,6 +33,8 @@
     handleTargetChange();
   }
 
+  $: console.log(target);
+
   function handleTargetChange() {
     if ($selected.value === target) {
       return;

--- a/src/renderer/main/panels/preferences/MeltSelect.svelte
+++ b/src/renderer/main/panels/preferences/MeltSelect.svelte
@@ -8,7 +8,7 @@
 
   function getDefaultSelected() {
     const obj = options.find((e: SelectOption) => e.value === target);
-    return { label: obj.title, value: obj.value };
+    return { label: obj?.title, value: obj?.value };
   }
 
   const {
@@ -25,13 +25,28 @@
     defaultSelected: getDefaultSelected(),
   });
 
-  $: handleSelectionChange($selected);
+  $: if ($selected) {
+    handleSelectionChange();
+  }
 
-  function handleSelectionChange(selected: { label: string; value: any }) {
-    if (selected === target) {
+  $: if (target) {
+    handleTargetChange();
+  }
+
+  function handleTargetChange() {
+    if ($selected.value === target) {
       return;
     }
-    target = selected.value;
+
+    const obj = options.find((e: SelectOption) => e.value === target);
+    selected.set({ label: obj?.title, value: obj?.value });
+  }
+
+  function handleSelectionChange() {
+    if ($selected.value === target) {
+      return;
+    }
+    target = $selected.value;
   }
 </script>
 

--- a/src/renderer/main/panels/preferences/MeltSelect.svelte
+++ b/src/renderer/main/panels/preferences/MeltSelect.svelte
@@ -33,8 +33,6 @@
     handleTargetChange();
   }
 
-  $: console.log(target);
-
   function handleTargetChange() {
     if ($selected.value === target) {
       return;


### PR DESCRIPTION
Closes #560 

The fixed issue was the instable state management of MeltSelect.svelte. Fixed the selection state management logic.

## Testing

The stresstesting of the select list is probably the way to go.

This component is used as a dropdown list in the following parts of editor:

- [x] In the tracker options (track events, elements, or off)
- [x] In the preferences menu
- [x] In the configuration menu, with the control element selection
- [x] In the virtual module adder modal, with the type selection

Closes #582 

Test dropdown for control element selection on Configuration panel in virtual mode too. See original issue of #582