### PR TITLE
🚩PR: NVM erase not flushing runtime is fixed

### DIFF
--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { configManager } from "./../configuration/Configuration.store.js";
   import { logger } from "./../../../runtime/runtime.store.js";
   import { writable, get } from "svelte/store";
   import { instructions } from "../../../serialport/instructions";
@@ -263,11 +264,13 @@
             .sendNVMEraseToGrid()
             .then((res) => {
               runtime.erase();
-              logger.set({
-                type: "success",
-                mode: 0,
-                classname: "nvmerase",
-                message: `Erase complete!`,
+              configManager.refresh().then(() => {
+                logger.set({
+                  type: "success",
+                  mode: 0,
+                  classname: "nvmerase",
+                  message: `Erase complete!`,
+                });
               });
             })
             .catch((e) => {

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -559,6 +559,7 @@ function create_runtime() {
           page.control_elements.forEach((events) => {
             events.events.forEach((event) => {
               event.config = undefined;
+              event.stored = undefined;
             });
           });
         });


### PR DESCRIPTION
Closes #594 

When having a module with the newest nightly firmware (the module should not disconnect during clear or NVM erase):

Now the runtime is cleared during NVM erase, and the config manager is updated to reflect the (actual) clean state of the module after the operation.