### PR TITLE
🚩PR: Fixed error of unhandled exception when scheduler breaks

### DIFF
--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -60,7 +60,7 @@
     const { dx, dy } = obj;
     const ui = get(user_input);
 
-    const target = new ConfigTarget({
+    const target = ConfigTarget.create({
       device: { dx: dx, dy: dy },
       page: ui.pagenumber,
       element: elementNumber,

--- a/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/underlays/ActiveChanges.svelte
@@ -20,7 +20,7 @@
     const { dx, dy } = obj;
     const ui = get(user_input);
 
-    const target = new ConfigTarget({
+    const target = ConfigTarget.create({
       device: { dx: dx, dy: dy },
       page: ui.pagenumber,
       element: elementNumber,

--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -321,35 +321,35 @@ export class ConfigList extends Array {
 }
 
 export class ConfigTarget {
-  constructor({ device: { dx: dx, dy: dy }, page, element, eventType }) {
+  static create({ device: { dx: dx, dy: dy }, page, element, eventType }) {
     const device = get(runtime).find((e) => e.dx == dx && e.dy == dy);
+
     if (typeof device === "undefined") {
-      throw "Unknown device!";
+      console.error("Unknown device!");
+      return undefined;
     }
 
-    this.device = { dx: dx, dy: dy };
-    this.page = page;
-    this.element = element;
-    this.eventType = eventType;
+    const target = new ConfigTarget();
+    target.device = { dx: dx, dy: dy };
+    target.page = page;
+    target.element = element;
+    target.eventType = eventType;
 
     const controlElement = device.pages
       .at(page)
       .control_elements.find((e) => e.controlElementNumber == element);
-    this.events = controlElement.events;
-    this.elementType = controlElement.controlElementType;
+    target.events = controlElement.events;
+    target.elementType = controlElement.controlElementType;
+    return target;
   }
 
   static createFrom({ userInput }) {
-    try {
-      return new ConfigTarget({
-        device: { dx: userInput.dx, dy: userInput.dy },
-        page: userInput.pagenumber,
-        element: userInput.elementnumber,
-        eventType: userInput.eventtype,
-      });
-    } catch (e) {
-      return undefined;
-    }
+    return ConfigTarget.create({
+      device: { dx: userInput.dx, dy: userInput.dy },
+      page: userInput.pagenumber,
+      element: userInput.elementnumber,
+      eventType: userInput.eventtype,
+    });
   }
 
   getEvent() {
@@ -404,19 +404,14 @@ export class ConfigTarget {
 
   static getCurrent() {
     const ui = get(user_input);
-    try {
-      const currentTarget = new ConfigTarget({
-        device: { dx: ui.dx, dy: ui.dy },
-        page: ui.pagenumber,
-        element: ui.elementnumber,
-        eventType: ui.eventtype,
-      });
+    const currentTarget = ConfigTarget.create({
+      device: { dx: ui.dx, dy: ui.dy },
+      page: ui.pagenumber,
+      element: ui.elementnumber,
+      eventType: ui.eventtype,
+    });
 
-      return currentTarget;
-    } catch (e) {
-      console.error("ConfigTarget:", e);
-      return undefined;
-    }
+    return currentTarget;
   }
 }
 

--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -370,7 +370,7 @@
 
         const data = [];
         for (const event of current.events) {
-          const target = new ConfigTarget({
+          const target = ConfigTarget.create({
             device: current.device,
             element: current.element,
             eventType: event.type,
@@ -427,7 +427,7 @@
     const promises = [];
     for (const e of current.events) {
       const eventtype = e.type;
-      const target = new ConfigTarget({
+      const target = ConfigTarget.create({
         device: current.device,
         element: current.element,
         eventType: eventtype,

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -46,6 +46,7 @@
 
   function handleUserInputChange(ui) {
     const target = ConfigTarget.createFrom({ userInput: ui });
+    console.log(target);
 
     if (typeof target === "undefined") {
       options = Array.from(Array(3).keys()).map((i) =>

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -1229,6 +1229,7 @@ const grid_heartbeat_interval_handler = async function () {
 
     if (elapsedTime > elapsedTimeLimit) {
       // TIMEOUT! let's remove the device
+      console.log("DESTROY", elapsedTime, `(${elapsedTimeLimit})`);
       runtime.destroy_module(device.dx, device.dy);
       heartbeat.update((heartbeat) => {
         return heartbeat.filter((e) => e.id !== device.id);


### PR DESCRIPTION
Closes #580 

The detailed description of the fixed bug can be found in the linked ticket.

**IMPORTANT:** The module during fast cycling repeats actually disconnects and reconnects, since the rate of received heartbeats slow down. This is also an issue.

The fix contains the elimination of the unhandled exception during the repeated and immediate drop and re-connection of a module. The unhandled exception should not appear now when reproducing the bug, only the (normal) error message in the console. 

The editor now should not freeze when this occure, and should be operational when the sequencer is stopped, the cycle rate is decreased or when the module is re-connected physically.