### PR TITLE
Changed runtime to ProtectedStore

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.store.js
+++ b/src/renderer/main/panels/configuration/Configuration.store.js
@@ -396,7 +396,7 @@ export class ConfigTarget {
             event: this.eventType,
           })
           .then(() => {
-            resolve(event.config);
+            resolve(this.getEvent().config);
           })
           .catch((e) => reject(e));
       } else {

--- a/src/renderer/protocol/grid-protocol.ts
+++ b/src/renderer/protocol/grid-protocol.ts
@@ -523,7 +523,7 @@ const moduleElements: { [key in ModuleType]: ElementType[] } = {
     ...Array(4).fill(ElementType.POTENTIOMETER),
     ...Array(4).fill(ElementType.FADER),
     ...Array(4).fill(ElementType.BUTTON),
-    ...Array(239), // Filling with undefined values until index 254
+    ...Array(243), // Filling with undefined values until index 254
     ElementType.SYSTEM, // Add system element at index 255
   ],
   [ModuleType.BU16]: [

--- a/src/renderer/runtime/smart-store.store.ts
+++ b/src/renderer/runtime/smart-store.store.ts
@@ -1,0 +1,26 @@
+import { writable, derived, Readable, Writable } from "svelte/store";
+
+export class ProtectedStore<T> implements Readable<T> {
+  public internal: Writable<T>;
+  private external: Readable<T>;
+
+  constructor(defaultValue?: T) {
+    this.internal = writable(defaultValue);
+
+    this.external = derived(this.internal, ($internal) => {
+      return Object.freeze(structuredClone($internal));
+    });
+
+    this.subscribe = this.external.subscribe.bind(this.external);
+  }
+
+  subscribe: Readable<T>["subscribe"];
+
+  set(value: T) {
+    this.internal.set(value);
+  }
+
+  update(func: (param: T) => T) {
+    this.internal.update(func);
+  }
+}


### PR DESCRIPTION
A new protected store (as seen in user_input) is introduced.
This protected store is used for user_input and for runtime now.

The ProtectedStore class implements a write protected store, thats value can only be modified by calling set or update, never directly.