### PR TITLE
🚩PR: Added feature of GridLayout repositioning

### DIFF
--- a/src/renderer/main/MiddlePanelContainer.svelte
+++ b/src/renderer/main/MiddlePanelContainer.svelte
@@ -12,6 +12,7 @@
   import ModuleHangingDialog from "./user-interface/ModuleHangingDialog.svelte";
   import StickyContainer from "./user-interface/StickyContainer.svelte";
   import { onMount } from "svelte";
+  import ControlSurface from "./panels/configuration/components/ControlSurface.svelte";
 
   let logLength = 0;
   let trackerVisible = true;
@@ -72,14 +73,15 @@
   id="container"
   class="relative flex flex-col w-full h-full overflow-clip justify-center"
 >
+  <ControlSurface />
   {#if showFixedStickyContainer}
     <StickyContainer
-      class="absolute z-[1] bottom-0 left-1/2 -translate-x-1/2 mb-5"
+      class="absolute z-[2] bottom-0 left-1/2 -translate-x-1/2 mb-5"
     />
   {/if}
 
   <div
-    class="absolute top-0 w-fit self-center mt-10 z-[1] bg-primary rounded-lg py-2 px-4 items-center flex-wrap justify-center"
+    class="absolute top-0 w-fit self-center mt-10 z-[2] bg-primary rounded-lg py-2 px-4 items-center flex-wrap justify-center"
   >
     {#if showModuleHangingDialog}
       <ModuleHangingDialog />
@@ -91,7 +93,9 @@
   <GridLayout
     bind:component={gridLayout}
     on:resize={handleResize}
-    class="absolute z-[0] items-center flex flex-col self-center"
+    class="absolute z-[0] top-1/2 left-1/2 flex flex-col"
+    style="transform: translate(calc(-50% + {$appSettings.gridLayoutShift
+      .x}px), calc(-50% + {$appSettings.gridLayoutShift.y}px));"
   >
     <div
       id="sticky-container"
@@ -124,7 +128,7 @@
     {/if}
 
     <CursorLog
-      class="absolute bottom-0 left-1/2 -translate-x-1/2 mb-4 z-[1]"
+      class="absolute bottom-0 left-1/2 -translate-x-1/2 mb-4 z-[2]"
       on:content-change={handleContentChange}
     />
   </div>

--- a/src/renderer/main/MiddlePanelContainer.svelte
+++ b/src/renderer/main/MiddlePanelContainer.svelte
@@ -36,15 +36,26 @@
     const stickyRect = stickyContainer.getBoundingClientRect();
     const threshold = -15;
 
-    showFixedStickyContainer = !(
-      stickyRect.bottom <
-      contRect.bottom + threshold
-    );
+    showFixedStickyContainer =
+      stickyRect.bottom >= contRect.bottom + threshold ||
+      stickyRect.top <= contRect.top - threshold ||
+      stickyRect.left <= contRect.left - threshold ||
+      stickyRect.right >= contRect.right + threshold;
   }
 
   onMount(() => {
     window.addEventListener("resize", handleResize, true);
   });
+
+  function handleGridLayoutShift(vector) {
+    if (vector.x === 0 && vector.y === 0) {
+      return;
+    }
+
+    handleResize();
+  }
+
+  $: handleGridLayoutShift($appSettings.gridLayoutShift);
 
   let showModuleHangingDialog = false;
   let moduleHangingTimeout = undefined;

--- a/src/renderer/main/grid-layout/GridLayout.svelte
+++ b/src/renderer/main/grid-layout/GridLayout.svelte
@@ -150,7 +150,8 @@
 </script>
 
 <layout-container
-  class="{$$props.class} "
+  class={$$props.class}
+  style={$$props.style}
   bind:this={component}
   use:watchResize={handleResize}
 >

--- a/src/renderer/main/panels/configuration/components/ControlSurface.svelte
+++ b/src/renderer/main/panels/configuration/components/ControlSurface.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { get } from "svelte/store";
+  import { appSettings } from "../../../../runtime/app-helper.store";
+  import { onDestroy, onMount } from "svelte";
+
+  let trackMouse = false;
+  let dragMouse = false;
+
+  interface Point {
+    x: number;
+    y: number;
+  }
+
+  let startPoint: Point = { x: 0, y: 0 };
+  let previousVector = undefined;
+
+  function handleKeyEvent(e) {
+    if (e.key !== "Control") {
+      return;
+    } else {
+      //Filter out continous press
+      if (e.type === "keydown" && trackMouse) {
+        return;
+      }
+    }
+
+    switch (e.type) {
+      case "keydown": {
+        trackMouse = true;
+        break;
+      }
+      case "keyup": {
+        trackMouse = false;
+        break;
+      }
+    }
+  }
+
+  function handleMouseEvent(e) {
+    if (e.button !== 0) {
+      return;
+    }
+
+    switch (e.type) {
+      case "mousedown": {
+        if (!trackMouse) {
+          return;
+        }
+        startPoint = { x: e.screenX, y: e.screenY };
+        dragMouse = true;
+        const current = get(appSettings).gridLayoutShift;
+        if (current.x === 0 && current.y === 0) {
+          previousVector = current;
+        }
+        break;
+      }
+      case "mouseup": {
+        dragMouse = false;
+        previousVector = get(appSettings).gridLayoutShift;
+        break;
+      }
+    }
+  }
+
+  function handleMouseMove(e) {
+    if (!dragMouse) {
+      return;
+    }
+
+    const endPoint = { x: e.screenX, y: e.screenY };
+    calculateShiftVector(startPoint, endPoint);
+  }
+
+  function calculateShiftVector(p1: Point, p2: Point) {
+    let vector: Point = { x: p2.x - p1.x, y: p2.y - p1.y };
+    if (typeof previousVector !== "undefined") {
+      vector = {
+        x: previousVector.x + vector.x,
+        y: previousVector.y + vector.y,
+      };
+    }
+
+    appSettings.update((s) => {
+      s.gridLayoutShift = vector;
+      return s;
+    });
+  }
+
+  onMount(() => {
+    document.addEventListener("keydown", handleKeyEvent);
+    document.addEventListener("keyup", handleKeyEvent);
+    document.addEventListener("mousedown", handleMouseEvent);
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseEvent);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener("keydown", handleKeyEvent);
+    document.removeEventListener("keyup", handleKeyEvent);
+    document.removeEventListener("mousedown", handleMouseEvent);
+    document.removeEventListener("mousemove", handleMouseMove);
+    document.removeEventListener("mouseup", handleMouseEvent);
+  });
+</script>
+
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<container
+  class="absolute w-full h-full z-[1]"
+  class:pointer-events-none={!trackMouse}
+  class:cursor-grab={trackMouse}
+/>

--- a/src/renderer/main/panels/configuration/components/ControlSurface.svelte
+++ b/src/renderer/main/panels/configuration/components/ControlSurface.svelte
@@ -26,14 +26,22 @@
 
     switch (e.type) {
       case "keydown": {
-        trackMouse = true;
+        handleKeyDown(e);
         break;
       }
       case "keyup": {
-        trackMouse = false;
+        handleKeyUp(e);
         break;
       }
     }
+  }
+
+  function handleKeyDown(e) {
+    trackMouse = true;
+  }
+
+  function handleKeyUp(e) {
+    trackMouse = false;
   }
 
   function handleMouseEvent(e) {
@@ -43,23 +51,31 @@
 
     switch (e.type) {
       case "mousedown": {
-        if (!trackMouse) {
-          return;
-        }
-        startPoint = { x: e.screenX, y: e.screenY };
-        dragMouse = true;
-        const current = get(appSettings).gridLayoutShift;
-        if (current.x === 0 && current.y === 0) {
-          previousVector = current;
-        }
+        handleMouseDown(e);
         break;
       }
       case "mouseup": {
-        dragMouse = false;
-        previousVector = get(appSettings).gridLayoutShift;
+        handleMouseUp(e);
         break;
       }
     }
+  }
+
+  function handleMouseDown(e) {
+    if (!trackMouse) {
+      return;
+    }
+    startPoint = { x: e.screenX, y: e.screenY };
+    dragMouse = true;
+    const current = get(appSettings).gridLayoutShift;
+    if (current.x === 0 && current.y === 0) {
+      previousVector = current;
+    }
+  }
+
+  function handleMouseUp(e) {
+    dragMouse = false;
+    previousVector = get(appSettings).gridLayoutShift;
   }
 
   function handleMouseMove(e) {
@@ -101,11 +117,17 @@
     document.removeEventListener("mousemove", handleMouseMove);
     document.removeEventListener("mouseup", handleMouseEvent);
   });
+
+  function handleMouseLeave(e) {
+    handleKeyUp(e);
+    handleMouseUp(e);
+  }
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <container
   class="absolute w-full h-full z-[1]"
+  on:mouseleave={handleMouseLeave}
   class:pointer-events-none={!trackMouse}
   class:cursor-grab={trackMouse}
 />

--- a/src/renderer/main/panels/configuration/components/ControlSurface.svelte
+++ b/src/renderer/main/panels/configuration/components/ControlSurface.svelte
@@ -120,7 +120,7 @@
   }
 </script>
 
-<svelte:body on:keydown={handleKeyEvent} on:keyup={handleKeyEvent} />
+<svelte:window on:keydown={handleKeyEvent} on:keyup={handleKeyEvent} />
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <container
@@ -128,5 +128,6 @@
   class="absolute w-full h-full z-[1]"
   on:mouseleave={handleMouseLeave}
   class:pointer-events-none={!trackMouse}
+  class:cursor-grabbing={dragMouse}
   class:cursor-grab={trackMouse}
 />

--- a/src/renderer/main/panels/configuration/components/ControlSurface.svelte
+++ b/src/renderer/main/panels/configuration/components/ControlSurface.svelte
@@ -120,10 +120,7 @@
   }
 </script>
 
-<svelte:body
-  on:keydown|preventDefault={handleKeyEvent}
-  on:keyup|preventDefault={handleKeyEvent}
-/>
+<svelte:body on:keydown={handleKeyEvent} on:keyup={handleKeyEvent} />
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <container

--- a/src/renderer/main/panels/configuration/components/ControlSurface.svelte
+++ b/src/renderer/main/panels/configuration/components/ControlSurface.svelte
@@ -103,16 +103,12 @@
   }
 
   onMount(() => {
-    document.addEventListener("keydown", handleKeyEvent);
-    document.addEventListener("keyup", handleKeyEvent);
     document.addEventListener("mousedown", handleMouseEvent);
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseEvent);
   });
 
   onDestroy(() => {
-    document.removeEventListener("keydown", handleKeyEvent);
-    document.removeEventListener("keyup", handleKeyEvent);
     document.removeEventListener("mousedown", handleMouseEvent);
     document.removeEventListener("mousemove", handleMouseMove);
     document.removeEventListener("mouseup", handleMouseEvent);
@@ -124,8 +120,14 @@
   }
 </script>
 
+<svelte:body
+  on:keydown|preventDefault={handleKeyEvent}
+  on:keyup|preventDefault={handleKeyEvent}
+/>
+
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <container
+  id="surface"
   class="absolute w-full h-full z-[1]"
   on:mouseleave={handleMouseLeave}
   class:pointer-events-none={!trackMouse}

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -372,8 +372,14 @@
       updateFontSize($appSettings.persistent.fontSize);
     }
   }
+
+  function handleMouseOut(e) {
+    window.focus();
+  }
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div class="flex flex-col bg-primary w-full h-full relative">
   <div class="flex items-center justify-center h-full absolute">
     {#if !profileCloudIsMounted}
@@ -392,8 +398,10 @@
     {/if}
   </div>
 
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <iframe
     bind:this={iframe_element}
+    on:mouseout={handleMouseOut}
     class="w-full h-full {profileCloudIsMounted ? '' : ' hidden'}"
     title="Test"
     allow="clipboard-read; clipboard-write;}"

--- a/src/renderer/main/user-interface/Tracker.svelte
+++ b/src/renderer/main/user-interface/Tracker.svelte
@@ -2,6 +2,9 @@
   import { appSettings } from "../../runtime/app-helper.store";
   import { Analytics } from "../../runtime/analytics.js";
   import { MeltSelect } from "@intechstudio/grid-uikit";
+  import MoltenPushButton, {
+    ButtonSnap,
+  } from "../panels/preferences/MoltenPushButton.svelte";
 
   const options = [
     {
@@ -20,16 +23,32 @@
       tooltip_key: "tracker_event",
     },
   ];
+
+  function handleGridLayoutResetClicked(e) {
+    appSettings.update((s) => {
+      s.gridLayoutShift = { x: 0, y: 0 };
+      return s;
+    });
+  }
 </script>
 
 <container class={$$props.class}>
-  <div class="flex items-center bg-primary py-2 px-3 rounded-lg">
-    <span class="text-white mr-4">Interaction Tracking:</span>
-    <div class="w-24 h-fit text-white">
-      <MeltSelect
-        bind:target={$appSettings.persistent.changeOnEvent}
-        {options}
-      />
+  <div class="flex flex-col items-center gap-2 bg-primary py-2 px-3 rounded-lg">
+    <div class="flex flex-row items-center">
+      <span class="text-white mr-4">Interaction Tracking:</span>
+      <div class="w-24 h-fit text-white">
+        <MeltSelect
+          bind:target={$appSettings.persistent.changeOnEvent}
+          {options}
+        />
+      </div>
     </div>
+    <MoltenPushButton
+      text={"Reset Grid Layout"}
+      on:click={handleGridLayoutResetClicked}
+      snap={ButtonSnap.FULL}
+      disabled={$appSettings.gridLayoutShift.x == 0 &&
+        $appSettings.gridLayoutShift.y == 0}
+    />
   </div>
 </container>

--- a/src/renderer/main/user-interface/Tracker.svelte
+++ b/src/renderer/main/user-interface/Tracker.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { setTooltip } from "./tooltip/Tooltip.ts";
   import TooltipQuestion from "./tooltip/TooltipQuestion.svelte";
   import { appSettings } from "../../runtime/app-helper.store";
   import { Analytics } from "../../runtime/analytics.js";
@@ -34,20 +35,32 @@
 </script>
 
 <container class={$$props.class}>
-  <div class="flex flex-col items-center gap-2 bg-primary py-2 px-3 rounded-lg">
-    <div class="flex flex-row items-center">
-      <span class="text-white mr-4">Interaction Tracking:</span>
-      <div class="w-24 h-fit text-white">
+  <div class="flex flex-row items-center gap-2 bg-primary py-2 px-3 rounded-lg">
+    <div class="flex flex-row gap-2 items-center">
+      <span class="text-white">Track:</span>
+      <div
+        use:setTooltip={{
+          placement: "top",
+          class: "w-60 p-4 z-10",
+          key: "tracker_tooltip",
+        }}
+        class="w-24 h-fit text-white"
+      >
         <MeltSelect
           bind:target={$appSettings.persistent.changeOnEvent}
           {options}
         />
       </div>
     </div>
-    <div class="flex flex-row w-full items-center">
-      <TooltipQuestion key={"reset_grid_layout"} class="mr-2 text-white " />
+    <div
+      use:setTooltip={{
+        placement: "top",
+        class: "w-60 p-4 z-10",
+        key: "reset_grid_layout",
+      }}
+    >
       <MoltenPushButton
-        text={"Reset Grid Layout"}
+        text={"Reset View"}
         on:click={handleGridLayoutResetClicked}
         snap={ButtonSnap.FULL}
         disabled={$appSettings.gridLayoutShift.x == 0 &&

--- a/src/renderer/main/user-interface/Tracker.svelte
+++ b/src/renderer/main/user-interface/Tracker.svelte
@@ -1,4 +1,5 @@
 <script>
+  import TooltipQuestion from "./tooltip/TooltipQuestion.svelte";
   import { appSettings } from "../../runtime/app-helper.store";
   import { Analytics } from "../../runtime/analytics.js";
   import { MeltSelect } from "@intechstudio/grid-uikit";
@@ -43,12 +44,15 @@
         />
       </div>
     </div>
-    <MoltenPushButton
-      text={"Reset Grid Layout"}
-      on:click={handleGridLayoutResetClicked}
-      snap={ButtonSnap.FULL}
-      disabled={$appSettings.gridLayoutShift.x == 0 &&
-        $appSettings.gridLayoutShift.y == 0}
-    />
+    <div class="flex flex-row w-full items-center">
+      <TooltipQuestion key={"reset_grid_layout"} class="mr-2 text-white " />
+      <MoltenPushButton
+        text={"Reset Grid Layout"}
+        on:click={handleGridLayoutResetClicked}
+        snap={ButtonSnap.FULL}
+        disabled={$appSettings.gridLayoutShift.x == 0 &&
+          $appSettings.gridLayoutShift.y == 0}
+      />
+    </div>
   </div>
 </container>

--- a/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
+++ b/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
@@ -171,4 +171,6 @@ export const tooltip_content = {
     "Always change to the element and event of your grid module(s) on interaction. This is useful when you want to configure the functions (e.g.: slider potmeter event) of your grid module(s)",
   raw_block_what_happened_text:
     "New version of this block is available, click on Update to restore your configuration.",
+  reset_grid_layout:
+    "The displayed modules can be repositioned by click and dragging the mouse while holding the control key.",
 };

--- a/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
+++ b/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
@@ -173,4 +173,6 @@ export const tooltip_content = {
     "New version of this block is available, click on Update to restore your configuration.",
   reset_grid_layout:
     "The displayed modules can be repositioned by click and dragging the mouse while holding the control key.",
+  tracker_tooltip:
+    "When changing a control element, the tracking option determines selection scope.",
 };

--- a/src/renderer/runtime/app-helper.store.js
+++ b/src/renderer/runtime/app-helper.store.js
@@ -105,6 +105,7 @@ function createAppSettingsStore(persistent) {
       owner: { neme: undefined },
     },
     packageList: [],
+    gridLayoutShift: { x: 0, y: 0 },
     persistent: structuredClone(persistent),
   });
 

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -930,7 +930,7 @@ function create_runtime() {
       return rt;
     });
 
-    if (_runtime.length === 0) {
+    if (get(_runtime).length === 0) {
       appSettings.update((s) => {
         s.gridLayoutShift = { x: 0, y: 0 };
         return s;

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -918,6 +918,13 @@ function create_runtime() {
       return rt;
     });
 
+    if (_runtime.length === 0) {
+      appSettings.update((s) => {
+        s.gridLayoutShift = { x: 0, y: 0 };
+        return s;
+      });
+    }
+
     user_input.module_destroy_handler(removed.dx, removed.dy);
     if (removed.architecture === "virtual") {
       virtual_modules.set([]);


### PR DESCRIPTION
Closes #445 

- Now when holding down the control key and click + dragging with the mouse, the displayed modules can be repositioned
- This repositioning is resets when clicking the Reset Grid Layout button on the Tracker
- Check the tooltip for this feature next to the reset button
- When the sticky container (that contains the page changer buttons) is would be outside of the middle panel, then it automatically sticks to the bottom of the screen
- When no module is connected the positioning is reseted to the center
- This feature is not persistent, the restart of the editor should reset the positioning.