### PR TITLE
🚩PR: Fixed unhandled promise when clearing module

### DIFF
--- a/src/renderer/main/user-interface/ActiveChanges.svelte
+++ b/src/renderer/main/user-interface/ActiveChanges.svelte
@@ -68,14 +68,20 @@
       .clearPage(ui.pagenumber)
       .then(() => {
         clearOverlays();
-        configManager.refresh().then(() => {
-          logger.set({
-            type: "success",
-            mode: 0,
-            classname: "pageclear",
-            message: `Page clear complete!`,
+        configManager
+          .refresh()
+          .then(() => {
+            logger.set({
+              type: "success",
+              mode: 0,
+              classname: "pageclear",
+              message: `Page clear complete!`,
+            });
+          })
+          .catch((e) => {
+            console.warn(e);
+            //TODO: make feedback for fail
           });
-        });
       })
       .catch((e) => {
         console.warn(e);


### PR DESCRIPTION
Closes #649 (and possibly #640)

The fixed issue is that with the current release firmware during clear, there is a high chance of dropping a module. During module drop, all instructions are cleared out from the buffer, and sometimes this causes an unhandled exceptions. This was fixed, solving the unhandled exceptions mentioned in the two original tickets

Repro steps for the bug of #649:

- Connect two modules  (BU16 and a PBF4 next to it on the left)
- Modify the (default) value of note on on the last button of PBF4 to midi CC on the button event
- Store
- Clear
- Repeat 1-5x times that should not create an unhandled exception, but print a consol warning with one of the texts mentioned in the original tickets

