### PR TITLE
🚩PR: Multiple Virtual Modules can now be added

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@electron/notarize": "^2.1.0",
-    "@intechstudio/grid-uikit": "^0.0.2",
     "@playwright/test": "^1.42.0",
     "@sveltejs/vite-plugin-svelte": "^2.4.5",
     "@types/node": "^20.11.21",
@@ -40,6 +39,7 @@
     "vite-plugin-monaco-editor": "^1.1.0"
   },
   "dependencies": {
+    "@intechstudio/grid-uikit": "^0.0.4",
     "adm-zip": "^0.5.10",
     "chokidar": "^3.5.3",
     "discord.js": "^13.6.0",

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -154,7 +154,10 @@
   function open_monaco() {
     $monaco_store = { config: config.makeCopy(), index: index };
     $monaco_elementtype = access_tree.elementtype;
-    modal.show(Monaco, { snap: "middle", disableClickOutside: true });
+    modal.show({
+      component: Monaco,
+      options: { snap: "middle", disableClickOutside: true },
+    });
   }
 </script>
 

--- a/src/renderer/main/modals/AddVirtualModule.svelte
+++ b/src/renderer/main/modals/AddVirtualModule.svelte
@@ -29,7 +29,6 @@
 
   $: {
     const args = $modal.args;
-    console.log(args);
     dx = args?.dx ?? 0;
     dy = args?.dy ?? 0;
   }

--- a/src/renderer/main/modals/AddVirtualModule.svelte
+++ b/src/renderer/main/modals/AddVirtualModule.svelte
@@ -25,13 +25,25 @@
     { id: ModuleType.TEK2, component: TEK2 },
   ];
 
+  let [dx, dy]: number[] = [0, 0];
+
+  $: {
+    const args = $modal.args;
+    console.log(args);
+    dx = args?.dx ?? 0;
+    dy = args?.dy ?? 0;
+  }
+
   let selectedModule: number = -1;
 
   function handleAddClicked(e) {
-    if (get(runtime).length > 0) {
-      runtime.destroy_module(0, 0);
+    const rt = get(runtime);
+    if (typeof rt.find((e) => e.dx === dx && e.dy === dy) !== "undefined") {
+      runtime.destroy_module(dx, dy);
     }
     runtime.addVirtualModule({
+      dx: dx,
+      dy: dy,
       type: devices[selectedModule].id,
     });
     modal.close();

--- a/src/renderer/main/modals/modal.store.ts
+++ b/src/renderer/main/modals/modal.store.ts
@@ -12,9 +12,12 @@ export type ModalOptions = {
   disableClickOutside?: boolean;
 };
 
+export type ModalArguments = any | undefined;
+
 type ModalStoreValue = {
   component: unknown;
   options: ModalOptions;
+  args: ModalArguments;
 };
 
 const defaultOptions: ModalOptions = {
@@ -25,13 +28,21 @@ const defaultOptions: ModalOptions = {
 function createModalStore() {
   const store = writable<ModalStoreValue | undefined>(undefined);
 
-  function show(
-    component: unknown,
-    options: ModalOptions = defaultOptions
-  ): void {
-    store.set({ component: component, options: options } as ModalStoreValue);
+  function show({
+    component,
+    options = defaultOptions,
+    args,
+  }: {
+    component: unknown;
+    options?: ModalOptions;
+    args?: ModalArguments;
+  }): void {
+    store.set({
+      component: component,
+      options: options,
+      args: args,
+    } as ModalStoreValue);
   }
-
   function close(): void {
     store.set(undefined);
   }

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -138,7 +138,7 @@
   }
 
   function handleShowCode(e) {
-    modal.show(Export);
+    modal.show({ component: Export });
   }
 </script>
 

--- a/src/renderer/main/panels/configuration/components/ExportConfigs.svelte
+++ b/src/renderer/main/panels/configuration/components/ExportConfigs.svelte
@@ -8,7 +8,7 @@
   <button
     id="open-export-modal"
     on:click|preventDefault={() => {
-      modal.show(Export);
+      modal.show({ component: Export });
     }}
     class="p-1 flex cursor-pointer focus:ring-1 focus:outline-none items-center hover:bg-select bg-secondary rounded"
   >

--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -21,6 +21,7 @@
     MeltSelect,
     MoltenButton,
     MoltenInput,
+    BlockColumn,
   } from "@intechstudio/grid-uikit";
   import { reduced_motion_store } from "../../../runtime/animations.js";
   import MoltenPushButton, { ButtonSnap } from "./MoltenPushButton.svelte";
@@ -417,8 +418,7 @@
     <Block>
       <BlockTitle>Virtual Module Management</BlockTitle>
       <BlockBody
-        >Scales the font size and control elements dimensions by keeping their
-        ratio compared to each other.</BlockBody
+        >Additional modules can be added or removed on a given coordinate.</BlockBody
       >
       <BlockRow>
         <BlockBody>DX</BlockBody>
@@ -426,7 +426,7 @@
         <BlockBody>DY</BlockBody>
         <MoltenInput bind:target={virtualModuleDY} />
       </BlockRow>
-      <div class="flex flex-col gap-2">
+      <BlockColumn>
         <MoltenPushButton
           text={"Add"}
           snap={ButtonSnap.FULL}
@@ -437,7 +437,7 @@
           snap={ButtonSnap.FULL}
           on:click={handleRemoveVirtualModuleClicked}
         />
-      </div>
+      </BlockColumn>
     </Block>
 
     <Block>

--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { modal } from "./../../modals/modal.store.ts";
+  import AddVirtualModule from "./../../modals/AddVirtualModule.svelte";
   import { configManager } from "./../configuration/Configuration.store.js";
   import { logger } from "./../../../runtime/runtime.store.js";
   import { writable, get } from "svelte/store";
@@ -21,6 +23,7 @@
     MoltenInput,
   } from "@intechstudio/grid-uikit";
   import { reduced_motion_store } from "../../../runtime/animations.js";
+  import MoltenPushButton, { ButtonSnap } from "./MoltenPushButton.svelte";
 
   const configuration = window.ctxProcess.configuration();
 
@@ -83,6 +86,24 @@
   ];
 
   let activePreferenceMenu = PreferenceMenu.GENERAL;
+
+  let virtualModuleDX: string = "0";
+  let virtualModuleDY: string = "0";
+
+  function handleAddVirtualModuleClicked() {
+    modal.show({
+      component: AddVirtualModule,
+      args: { dx: Number(virtualModuleDX), dy: Number(virtualModuleDY) },
+    });
+  }
+
+  function handleRemoveVirtualModuleClicked() {
+    const rt = get(runtime);
+    const [dx, dy] = [Number(virtualModuleDX), Number(virtualModuleDY)];
+    if (typeof rt.find((e) => e.dx === dx && e.dy === dy) !== "undefined") {
+      runtime.destroy_module(dx, dy);
+    }
+  }
 </script>
 
 <div
@@ -391,6 +412,32 @@
           }}
         />
       </BlockRow>
+    </Block>
+
+    <Block>
+      <BlockTitle>Virtual Module Management</BlockTitle>
+      <BlockBody
+        >Scales the font size and control elements dimensions by keeping their
+        ratio compared to each other.</BlockBody
+      >
+      <BlockRow>
+        <BlockBody>DX</BlockBody>
+        <MoltenInput bind:target={virtualModuleDX} />
+        <BlockBody>DY</BlockBody>
+        <MoltenInput bind:target={virtualModuleDY} />
+      </BlockRow>
+      <div class="flex flex-col gap-2">
+        <MoltenPushButton
+          text={"Add"}
+          snap={ButtonSnap.FULL}
+          on:click={handleAddVirtualModuleClicked}
+        />
+        <MoltenPushButton
+          text={"Remove"}
+          snap={ButtonSnap.FULL}
+          on:click={handleRemoveVirtualModuleClicked}
+        />
+      </div>
     </Block>
 
     <Block>

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -123,7 +123,7 @@
   }
 
   async function handleLoginToProfileCloud(event) {
-    modal.show(UserLogin);
+    modal.show({ component: UserLogin });
   }
 
   async function handleCreateCloudConfigLink(event) {

--- a/src/renderer/main/user-interface/ModulConnectionDialog.svelte
+++ b/src/renderer/main/user-interface/ModulConnectionDialog.svelte
@@ -27,12 +27,12 @@
 
   onMount(() => {
     if (window.ctxProcess.buildVariables().BUILD_TARGET === "web") {
-      modal.show(AddVirtualModule);
+      modal.show({ component: AddVirtualModule, args: { dx: 0, dy: 0 } });
     }
   });
 
   function handleAddVirtualModuleClicked(e) {
-    modal.show(AddVirtualModule);
+    modal.show({ component: AddVirtualModule, args: { dx: 0, dy: 0 } });
     Analytics.track({
       event: "VirtualModule",
       payload: {

--- a/src/renderer/main/user-interface/SendFeedback.svelte
+++ b/src/renderer/main/user-interface/SendFeedback.svelte
@@ -12,7 +12,7 @@
   function openFeedbackFrom(arg) {
     console.log("feedback on " + feedback_context);
 
-    modal.show(Feedback);
+    modal.show({ component: Feedback });
     $appSettings.feedback_context = feedback_context;
   }
 </script>

--- a/src/renderer/main/user-interface/StickyContainer.svelte
+++ b/src/renderer/main/user-interface/StickyContainer.svelte
@@ -4,7 +4,7 @@
   import { selectedConfigStore } from "../../runtime/config-helper.store";
   import { moduleOverlay } from "../../runtime/moduleOverlay";
   import MoltenPushButton from "../panels/preferences/MoltenPushButton.svelte";
-  import { virtual_modules } from "../../runtime/virtual-engine";
+  import { virtual_runtime } from "../../runtime/virtual-engine";
   import AddVirtualModule from "../modals/AddVirtualModule.svelte";
 </script>
 
@@ -20,11 +20,11 @@
         }}
       />
     {/if}
-    {#if $virtual_modules.length > 0}
+    {#if $virtual_runtime.length > 0}
       <MoltenPushButton
         text="Change Module"
         on:click={() => {
-          modal.show(AddVirtualModule);
+          modal.show({ component: AddVirtualModule, args: { dx: 0, dy: 0 } });
         }}
       />
     {/if}

--- a/src/renderer/runtime/app-helper.store.js
+++ b/src/renderer/runtime/app-helper.store.js
@@ -200,7 +200,7 @@ async function init_appsettings() {
           s.persistent.lastVersion = configuration["EDITOR_VERSION"];
           s.persistent.welcomeOnStartup = true;
           if (window.ctxProcess.buildVariables().BUILD_TARGET !== "web") {
-            modal.show(Welcome);
+            modal.show({ component: Welcome });
           }
           return s;
         });

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -6,7 +6,7 @@ import { appSettings } from "./app-helper.store";
 import { instructions } from "../serialport/instructions";
 import { simulateProcess } from "./virtual-engine";
 import { runtime } from "./runtime.store";
-import { virtual_modules } from "./virtual-engine";
+import { virtual_runtime } from "./virtual-engine";
 
 export enum InstructionClassName {
   HEARTBEAT = "HEARTBEAT",
@@ -355,10 +355,10 @@ function createWriteBuffer() {
       )!;
 
       //TODO: rework instructions into well defined ones,
-      //where the checking of virtual_modules is unnecessary
+      //where the checking of virtual_runtime is unnecessary
       if (
         sender?.architecture === "virtual" ||
-        get(virtual_modules).length > 0
+        get(virtual_runtime).length > 0
       ) {
         process = simulateProcess;
       } else {

--- a/src/renderer/runtime/runtime.store.js
+++ b/src/renderer/runtime/runtime.store.js
@@ -5,7 +5,7 @@ import { instructions } from "../serialport/instructions";
 import { writeBuffer, sendHeartbeat } from "./engine.store";
 import { createVirtualModule } from "./virtual-engine.ts";
 import { VirtualModuleHWCFG } from "./virtual-engine.ts";
-import { virtual_modules } from "./virtual-engine.ts";
+import { virtual_runtime } from "./virtual-engine.ts";
 
 import { Analytics } from "./analytics.js";
 
@@ -925,12 +925,10 @@ function create_runtime() {
 
   function destroy_module(dx, dy) {
     // remove the destroyed device from runtime
-    const removed = get(_runtime).find((g) => g.dx == dx && g.dy == dy);
+    const removed = get(_runtime).find((e) => e.dx == dx && e.dy == dy);
 
     _runtime.update((rt) => {
-      const index = rt.findIndex(
-        (e) => e.dx === removed.dx && e.dy === removed.dy
-      );
+      const index = rt.findIndex((e) => e.dx === dx && e.dy === dy);
       rt.splice(index, 1);
       return rt;
     });
@@ -942,9 +940,9 @@ function create_runtime() {
       });
     }
 
-    user_input.module_destroy_handler(removed.dx, removed.dy);
+    user_input.module_destroy_handler(dx, dy);
     if (removed.architecture === "virtual") {
-      virtual_modules.set([]);
+      virtual_runtime.destroyModule(dx, dy);
     } else {
       writeBuffer.module_destroy_handler(dx, dy);
     }
@@ -1104,14 +1102,14 @@ function create_runtime() {
     });
   }
 
-  function addVirtualModule({ type }) {
+  function addVirtualModule({ dx, dy, type }) {
     const module = VirtualModuleHWCFG[type];
     const controller = this.create_module(
       {
-        DX: 0,
-        DY: 0,
-        SX: 0,
-        SY: 0,
+        DX: dx,
+        DY: dy,
+        SX: dx,
+        SY: dy,
       },
       {
         HWCFG: module.hwcfg,
@@ -1119,7 +1117,7 @@ function create_runtime() {
       true
     );
 
-    createVirtualModule(0, 0, module.type);
+    createVirtualModule(dx, dy, module.type);
 
     _runtime.update((devices) => {
       return [...devices, controller];

--- a/src/renderer/runtime/virtual-engine.ts
+++ b/src/renderer/runtime/virtual-engine.ts
@@ -279,13 +279,9 @@ function create_virtual_runtime() {
     }
 
     store.update((s) => {
-      console.log(s);
       s.splice(index, 1);
-      console.log(s);
       return s;
     });
-
-    console.log();
   }
 
   return {

--- a/src/renderer/runtime/virtual-engine.ts
+++ b/src/renderer/runtime/virtual-engine.ts
@@ -51,7 +51,7 @@ function answerExecuteTypeRequest(obj: BufferElement) {
     ];
     switch (class_name) {
       case InstructionClassName.CONFIG: {
-        virtual_modules.update((s) => {
+        virtual_runtime.update((s) => {
           const device = s.find((e) => e.dx == dx && e.dy == dy);
           const events = device?.pages[page].elements.find(
             (e) => e.elementIndex === element
@@ -80,7 +80,7 @@ function answerExecuteTypeRequest(obj: BufferElement) {
         break;
       }
       case InstructionClassName.PAGESTORE: {
-        virtual_modules.update((s) => {
+        virtual_runtime.update((s) => {
           s.forEach((device) => {
             device.storeChanges();
           });
@@ -105,7 +105,7 @@ function answerExecuteTypeRequest(obj: BufferElement) {
         break;
       }
       case InstructionClassName.PAGECLEAR: {
-        virtual_modules.update((s) => {
+        virtual_runtime.update((s) => {
           s.forEach((device) => {
             device.resetDefaultConfiguration();
           });
@@ -130,7 +130,7 @@ function answerExecuteTypeRequest(obj: BufferElement) {
         break;
       }
       case InstructionClassName.PAGEDISCARD: {
-        virtual_modules.update((s) => {
+        virtual_runtime.update((s) => {
           s.forEach((device) => {
             device.discardChanges();
           });
@@ -171,7 +171,7 @@ function answerFetchTypeRequests(obj: BufferElement) {
       obj.descr.class_parameters.ELEMENTNUMBER ?? -1,
       obj.descr.class_parameters.EVENTTYPE ?? -1,
     ];
-    const device = get(virtual_modules).find((e) => e.dx === dx && e.dy === dy);
+    const device = get(virtual_runtime).find((e) => e.dx === dx && e.dy === dy);
     switch (class_name) {
       case InstructionClassName.CONFIG: {
         const events = device?.pages[page].elements.find(
@@ -268,11 +268,37 @@ class VirtualModule {
   }
 }
 
-export const virtual_modules = writable([] as VirtualModule[]);
+function create_virtual_runtime() {
+  const store = writable([] as VirtualModule[]);
+
+  function destroyModule(dx: number, dy: number) {
+    const vrt = get(store);
+    const index = vrt.findIndex((e) => e.dx === dx && e.dy === dy);
+    if (index === -1) {
+      return;
+    }
+
+    store.update((s) => {
+      console.log(s);
+      s.splice(index, 1);
+      console.log(s);
+      return s;
+    });
+
+    console.log();
+  }
+
+  return {
+    ...store,
+    destroyModule: destroyModule,
+  };
+}
+
+export const virtual_runtime = create_virtual_runtime();
 
 export function createVirtualModule(dx: number, dy: number, type: ModuleType) {
   const device = new VirtualModule(dx, dy, type);
-  virtual_modules.update((s) => [...s, device]);
+  virtual_runtime.update((s) => [...s, device]);
 }
 
 export function simulateProcess(obj: BufferElement): Promise<any> {


### PR DESCRIPTION
Closes #651 

The feature of adding multiple virtual modules is now added under developer settings.
The virtual modules can be added/removed by its coordinates. This reuses the virtual mode menu for module type selection when adding a new virtual module. 

- [ ] When the module under a certain coordinate does not exist, removing it should throw no error
- [ ] When a module already exist under a the coordinate you want to add another module, the module is replaced with the new one
- [ ] When connecting a physical module, all virtual modules should be destroyed