### PR TITLE
🚩PR: Added feature of nightly firmware update

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -17,6 +17,8 @@
   "FIRMWARE_GRID_ESP32_REQUIRED_MINOR": 2,
   "FIRMWARE_GRID_ESP32_REQUIRED_PATCH": 36,
   "FIRMWARE_GRID_URL_BEGINING": "https://github.com/intechstudio/grid-fw/releases/latest/download/",
+  "FIRMWARE_GRID_NIGHTLY_ESP32_URL": "https://github.com/intechstudio/grid-fw/raw/preview/Preview/Firmware/grid_esp32_nightly.uf2",
+  "FIRMWARE_GRID_NIGHTLY_D51_URL": "https://github.com/intechstudio/grid-fw/raw/preview/Preview/Firmware/grid_d51_nightly.uf2",
   "FIRMWARE_GRID_URL_END": "/grid_release.zip",
   "FIRMWARE_KNOT_URL_BEGINING": "https://github.com/intechstudio/knot/releases/latest/download/",
   "FIRMWARE_KNOT_URL_END": "/knot_release.zip",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -34,7 +34,12 @@ import { serial, restartSerialCheckInterval } from "./ipcmain_serialport";
 import { websocket } from "./ipcmain_websocket";
 import { store } from "./main-store";
 import { iconBuffer, iconSize } from "./icon";
-import { firmware, firmwareDownload, findBootloaderPath } from "./src/firmware";
+import {
+  firmware,
+  firmwareDownload,
+  firmwareNightlyDownload,
+  findBootloaderPath,
+} from "./src/firmware";
 import { updater, restartAfterUpdate } from "./src/updater";
 import {
   libraryDownload,
@@ -562,6 +567,11 @@ ipcMain.handle("deleteConfig", async (event, arg) => {
 ipcMain.handle("firmwareDownload", async (event, arg) => {
   return await firmwareDownload(arg.targetFolder);
 });
+
+ipcMain.handle("firmwareNightlyDownload", async (event, arg) => {
+  return await firmwareNightlyDownload(arg.targetFolder);
+});
+
 ipcMain.handle("findBootloaderPath", async (event, arg) => {
   return await findBootloaderPath();
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -31,6 +31,8 @@ contextBridge.exposeInMainWorld("electron", {
     findBootloaderPath: () => ipcRenderer.invoke("findBootloaderPath"),
     firmwareDownload: (targetFolder, arch, product) =>
       ipcRenderer.invoke("firmwareDownload", { targetFolder }),
+    firmwareNightlyDownload: (targetFolder, arch, product) =>
+      ipcRenderer.invoke("firmwareNightlyDownload", { targetFolder }),
   },
   serial: {
     restartSerialCheckInterval: () =>

--- a/src/electron/src/firmware.ts
+++ b/src/electron/src/firmware.ts
@@ -104,6 +104,92 @@ export async function findBootloaderPath() {
   }
 }
 
+export async function firmwareNightlyDownload(targetFolder) {
+  const result = await findBootloaderPath();
+
+  if (typeof result === "undefined") {
+    //bootloader not found
+    firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+      message: "Error: No device connected.",
+      code: 6,
+    });
+    return;
+  }
+
+  if (result.product !== "grid") {
+    firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+      message: `Error: Nightly firmware download for product (${result.product}) is not yet supported.`,
+      code: 7,
+    });
+    return;
+  }
+
+  const path = result.path;
+
+  let link = "";
+  switch (result.architecture) {
+    case "d51": {
+      link = configuration.FIRMWARE_GRID_NIGHTLY_D51_URL;
+      break;
+    }
+    case "esp32": {
+      link = configuration.FIRMWARE_GRID_NIGHTLY_ESP32_URL;
+      break;
+    }
+    default: {
+      firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+        message: `Error: Architecture (${result.architecture}) is not supported.`,
+        code: 9,
+      });
+      return;
+    }
+  }
+
+  firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+    message: "Downloading firmware image...",
+    code: 4,
+  });
+
+  const downloadPath = await downloadInMainProcess(link, "temp");
+  const firmwareFileName = downloadPath?.replace(/^.*[\\/]/, "");
+
+  if (typeof firmwareFileName === "undefined") {
+    firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+      message: "Error: Download failed.",
+      code: 3,
+    });
+
+    return;
+  }
+
+  await delay(1500);
+
+  firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+    message: "Uploading firmware...",
+    code: 4,
+  });
+
+  await delay(1500);
+
+  if (path !== undefined) {
+    try {
+      fs.copySync(
+        targetFolder + "/temp/" + firmwareFileName,
+        path + "/" + firmwareFileName
+      );
+    } catch (error) {
+      console.log("COPY ERROR UNBOUNT", error);
+    }
+
+    firmware.mainWindow.webContents.send("onFirmwareUpdate", {
+      message: "Update completed successfully!",
+      code: 5,
+    });
+  } else {
+    log.warn("GRID_NOT_FOUND");
+  }
+}
+
 export async function firmwareDownload(targetFolder) {
   const result = await findBootloaderPath();
 

--- a/src/renderer/main/FirmwareCheck.svelte
+++ b/src/renderer/main/FirmwareCheck.svelte
@@ -289,6 +289,7 @@ STATE 6 | Error               | Button  -> STATE 0 (Close notification)
     <button
       on:click={firmwareNightlyDownload}
       class="flex items-center justify-center rounded my-2 focus:outline-none border-2 border-select bg-select hover:bg-select-saturate-10 hover:border-select-saturate-10 text-white px-2 py-0.5 mr-2"
+      class:hidden={!$appSettings.persistent.nightlyFirmware}
     >
       Update (Nightly)
     </button>

--- a/src/renderer/main/FirmwareCheck.svelte
+++ b/src/renderer/main/FirmwareCheck.svelte
@@ -196,6 +196,26 @@ STATE 6 | Error               | Button  -> STATE 0 (Close notification)
     });
   }
 
+  async function firmwareNightlyDownload() {
+    const folder = $appSettings.persistent.profileFolder;
+    Analytics.track({
+      event: "FirmwareCheck",
+      payload: {
+        message: "Nightly Firmware Download Start",
+      },
+      mandatory: false,
+    });
+
+    await window.electron.firmware.firmwareNightlyDownload(folder);
+    Analytics.track({
+      event: "FirmwareCheck",
+      payload: {
+        message: "Nightly Firmware Download Finished",
+      },
+      mandatory: false,
+    });
+  }
+
   async function firmwareTroubleshooting() {
     Analytics.track({
       event: "FirmwareCheck",
@@ -264,6 +284,13 @@ STATE 6 | Error               | Button  -> STATE 0 (Close notification)
       class="flex items-center justify-center rounded my-2 focus:outline-none border-2 border-select bg-select hover:bg-select-saturate-10 hover:border-select-saturate-10 text-white px-2 py-0.5 mr-2"
     >
       Update Firmware
+    </button>
+
+    <button
+      on:click={firmwareNightlyDownload}
+      class="flex items-center justify-center rounded my-2 focus:outline-none border-2 border-select bg-select hover:bg-select-saturate-10 hover:border-select-saturate-10 text-white px-2 py-0.5 mr-2"
+    >
+      Update (Nightly)
     </button>
   </div>
 {/if}

--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -373,7 +373,7 @@
         shows.
       </BlockBody>
       <MeltCheckbox
-        bind:target={$appSettings.persistent.nightlyFirmware}
+        bind:target={$appSettings.persistent.showPCB}
         title={"Enabled"}
       />
     </Block>
@@ -385,8 +385,8 @@
         features and fixes. We suggest always staying on a Stable Firmware!
       </BlockBody>
       <MeltCheckbox
-        bind:target={$appSettings.persistent.showPCB}
-        title={"Show PCB"}
+        bind:target={$appSettings.persistent.nightlyFirmware}
+        title={"Enabled"}
       />
     </Block>
 

--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -397,6 +397,18 @@
         shows.
       </BlockBody>
       <MeltCheckbox
+        bind:target={$appSettings.persistent.nightlyFirmware}
+        title={"Enabled"}
+      />
+    </Block>
+
+    <Block>
+      <BlockTitle>Nightly Firmware Update</BlockTitle>
+      <BlockBody>
+        The Nightly Firmware version contains new, but potentially unstable
+        features and fixes. We suggest always staying on a Stable Firmware!
+      </BlockBody>
+      <MeltCheckbox
         bind:target={$appSettings.persistent.showPCB}
         title={"Show PCB"}
       />

--- a/src/renderer/runtime/app-helper.store.js
+++ b/src/renderer/runtime/app-helper.store.js
@@ -36,6 +36,7 @@ const persistentDefaultValues = {
   fontSize: 12,
   profileCloudUrl: configuration.PROFILE_CLOUD_URL_PROD,
   showPCB: false,
+  nightlyFirmware: false,
   changeOnEvent: "event",
   sendHeartbeatImmediate: false,
   disableAnimations: false,


### PR DESCRIPTION
Closes https://github.com/intechstudio/grid-editor/issues/689

When connecting a grid module in bootloader mode, now there is an available option to download the latest nightly firmware to the module. The nightly firmware is downloaded in the temp folder in the grid-userdata folder.