### PR TITLE
🚩PR: Fixed Copy/Paste for texts and fixed Icon display

### DIFF
--- a/src/renderer/main/_actions/shortcut.action.ts
+++ b/src/renderer/main/_actions/shortcut.action.ts
@@ -12,7 +12,20 @@ export const shortcut = (node: HTMLElement, params?: ShortcutParameter) => {
     setHandler = () => {
       removeHandler();
       if (!params) return;
+
       handler = (e: KeyboardEvent) => {
+        // Check if the event target is an input, textarea, or contenteditable element
+        const target = e.target as HTMLElement;
+        const isInputField =
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable;
+
+        // If the target is an input field, textarea, or contenteditable, allow default behavior
+        if (isInputField) {
+          return;
+        }
+
         if (
           !!params.alt != e.altKey ||
           !!params.shift != e.shiftKey ||

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -120,7 +120,11 @@
               class:icon-corner-cut-l={isLeftCut}
               class:scale-50={elementNumber == 255}
             >
-              <SvgIcon fill="#FFF" iconPath={loaded ? "tick" : "download"} />
+              <SvgIcon
+                class="text-white"
+                iconPath={loaded ? "tick" : "download"}
+                displayMode={"static"}
+              />
             </button>
           {/if}
         </div>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -120,11 +120,7 @@
               class:icon-corner-cut-l={isLeftCut}
               class:scale-50={elementNumber == 255}
             >
-              <SvgIcon
-                class="text-white"
-                iconPath={loaded ? "tick" : "download"}
-                displayMode={"static"}
-              />
+              <SvgIcon fill="#FFF" iconPath={loaded ? "tick" : "download"} />
             </button>
           {/if}
         </div>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -72,24 +72,20 @@
               {#if loadedState === 0}
                 <span class="text-white mr-2">Load Profile</span>
                 <SvgIcon
-                  class="text-white"
+                  fill="#FFF"
                   iconPath={"download"}
                   displayMode={"static"}
                 />
               {:else if loadedState === 1}
                 <span class="text-white mr-2">Loading...</span>
                 <SvgIcon
-                  class="text-white"
+                  fill="#FFF"
                   iconPath={"download"}
                   displayMode={"static"}
                 />
               {:else if loadedState === 2}
                 <span class="text-white">Loaded!</span>
-                <SvgIcon
-                  class="text-white"
-                  iconPath={"tick"}
-                  displayMode={"static"}
-                />
+                <SvgIcon fill="#FFF" iconPath={"tick"} displayMode={"static"} />
               {/if}
             </button>
           {/key}

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -72,20 +72,24 @@
               {#if loadedState === 0}
                 <span class="text-white mr-2">Load Profile</span>
                 <SvgIcon
-                  fill="#FFF"
+                  class="text-white"
                   iconPath={"download"}
                   displayMode={"static"}
                 />
               {:else if loadedState === 1}
                 <span class="text-white mr-2">Loading...</span>
                 <SvgIcon
-                  fill="#FFF"
+                  class="text-white"
                   iconPath={"download"}
                   displayMode={"static"}
                 />
               {:else if loadedState === 2}
                 <span class="text-white">Loaded!</span>
-                <SvgIcon fill="#FFF" iconPath={"tick"} displayMode={"static"} />
+                <SvgIcon
+                  class="text-white"
+                  iconPath={"tick"}
+                  displayMode={"static"}
+                />
               {/if}
             </button>
           {/key}

--- a/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
+++ b/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
@@ -289,10 +289,10 @@
                   <div class="flex items-center">
                     {#if message.data.direction == "REPORT"}
                       <span>RX</span>
-                      <SvgIcon class="scale-75" iconPath="arrow_left" />
+                      <SvgIcon fill="#FFF" iconPath="arrow_left" />
                     {:else}
                       <span>TX</span>
-                      <SvgIcon class="scale-75" iconPath="arrow_right" />
+                      <SvgIcon fill="#FFF" iconPath="arrow_right" />
                     {/if}
                   </div>
                 </div>
@@ -316,9 +316,9 @@
                   <div class="flex flex-row text-white">
                     <span>{midi.device.name}</span>
                     {#if midi.data.direction == "REPORT"}
-                      <SvgIcon class="scale-75" iconPath="arrow_left" />
+                      <SvgIcon fill="#FFF" iconPath="arrow_left" />
                     {:else}
-                      <SvgIcon class="scale-75" iconPath="arrow_right" />
+                      <SvgIcon fill="#FFF" iconPath="arrow_right" />
                     {/if}
                   </div>
                   <span>Ch: {midi.data.channel}</span>
@@ -384,9 +384,9 @@
                     <div class="flex flex-row text-white">
                       <span>{sysex.device.name}</span>
                       {#if sysex.data.direction == "REPORT"}
-                        <SvgIcon class="scale-75" iconPath="arrow_left" />
+                        <SvgIcon fill="#FFF" iconPath="arrow_left" />
                       {:else}
-                        <SvgIcon class="scale-75" iconPath="arrow_right" />
+                        <SvgIcon fill="#FFF" iconPath="arrow_right" />
                       {/if}
                     </div>
 

--- a/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
+++ b/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
@@ -289,10 +289,10 @@
                   <div class="flex items-center">
                     {#if message.data.direction == "REPORT"}
                       <span>RX</span>
-                      <SvgIcon fill="#FFF" iconPath="arrow_left" />
+                      <SvgIcon class="scale-75" iconPath="arrow_left" />
                     {:else}
                       <span>TX</span>
-                      <SvgIcon fill="#FFF" iconPath="arrow_right" />
+                      <SvgIcon class="scale-75" iconPath="arrow_right" />
                     {/if}
                   </div>
                 </div>
@@ -316,9 +316,9 @@
                   <div class="flex flex-row text-white">
                     <span>{midi.device.name}</span>
                     {#if midi.data.direction == "REPORT"}
-                      <SvgIcon fill="#FFF" iconPath="arrow_left" />
+                      <SvgIcon class="scale-75" iconPath="arrow_left" />
                     {:else}
-                      <SvgIcon fill="#FFF" iconPath="arrow_right" />
+                      <SvgIcon class="scale-75" iconPath="arrow_right" />
                     {/if}
                   </div>
                   <span>Ch: {midi.data.channel}</span>
@@ -384,9 +384,9 @@
                     <div class="flex flex-row text-white">
                       <span>{sysex.device.name}</span>
                       {#if sysex.data.direction == "REPORT"}
-                        <SvgIcon fill="#FFF" iconPath="arrow_left" />
+                        <SvgIcon class="scale-75" iconPath="arrow_left" />
                       {:else}
-                        <SvgIcon fill="#FFF" iconPath="arrow_right" />
+                        <SvgIcon class="scale-75" iconPath="arrow_right" />
                       {/if}
                     </div>
 

--- a/src/renderer/main/user-interface/SvgIcon.svelte
+++ b/src/renderer/main/user-interface/SvgIcon.svelte
@@ -2,7 +2,6 @@
   export let iconPath: string = "";
   export let width: number = 15;
   export let height: number = 15;
-  export let fill: string | undefined = undefined;
 
   let rawSvg: string;
 
@@ -15,7 +14,7 @@
   }
 </script>
 
-<svg style="width: {width}px; height: {height}px; fill: {fill};">
+<svg style="width: {width}px; height: {height}px;">
   <g>
     {@html rawSvg}
   </g>

--- a/src/renderer/main/user-interface/SvgIcon.svelte
+++ b/src/renderer/main/user-interface/SvgIcon.svelte
@@ -2,6 +2,7 @@
   export let iconPath: string = "";
   export let width: number = 15;
   export let height: number = 15;
+  export let fill: string | undefined = undefined;
 
   let rawSvg: string;
 
@@ -14,7 +15,7 @@
   }
 </script>
 
-<svg style="width: {width}px; height: {height}px;">
+<svg style="width: {width}px; height: {height}px; fill: {fill};">
   <g>
     {@html rawSvg}
   </g>


### PR DESCRIPTION
Closes #724 and #716

- Now copy/paste does not clash with monaco and line editor
- Added fill property for SvgIcons. This is now defined through the code, where necessary.
- Restored white fill for problematic SVG icons (see the original ticket of #716) 
