### PR TITLE
Fix display of midi channel

### DIFF
--- a/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
+++ b/src/renderer/main/panels/MidiMonitor/MidiMonitor.svelte
@@ -299,7 +299,7 @@
         <div class="border-gray-700 border rounded flex flex-col">
           <span class="text-white bg-secondary px-1 truncate">Channel</span>
           <span class="px-2 text-white text-center truncate"
-            >{last ? last.data.channel : "---"}</span
+            >{last ? last.data.channel + 1 : "---"}</span
           >
         </div>
         <div class="border-gray-700 border rounded flex flex-col">
@@ -382,7 +382,7 @@
                 >
                   <div>[{message.device.x}, {message.device.y}]</div>
                   {#if isMIDI(message)}
-                    <div>{message.data.channel}</div>
+                    <div>{message.data.channel + 1}</div>
                     <div>{message.data.command.value}</div>
                     <div>{message.data.params.p1.value}</div>
                     <div>{message.data.params.p2.value}</div>
@@ -428,7 +428,7 @@
                       <SvgIcon fill="#FFF" iconPath="arrow_right" />
                     {/if}
                   </div>
-                  <span class="truncate">Ch: {midi.data.channel}</span>
+                  <span class="truncate">Ch: {midi.data.channel + 1}</span>
                   <span class="truncate">{midi.data.command.short}</span>
                   <span class="truncate">{midi.data.params.p1.short}:</span>
                   <span class="truncate"


### PR DESCRIPTION
Unsure if fixing this in the template layer is the proper fix, but saw that being done elsewhere.

Was seeing the 0 based raw MIDI channel in the monitor.

![Screenshot 2025-01-28 at 18 37 26](https://github.com/user-attachments/assets/12510680-e4bb-4880-a34c-dc2c179ce13e)
![Screenshot 2025-01-28 at 18 37 36](https://github.com/user-attachments/assets/f4909cd7-b1ee-401e-a37a-5d8deb406518)

But the actual value was this:

![Screenshot 2025-01-28 at 18 37 51](https://github.com/user-attachments/assets/081e10f8-b879-49af-8d3a-73ded7c847f4)