### PR TITLE
Fixed drag-and-drop logic, and added drag animations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: 'bug: '
-labels: ''
-assignees: ''
-
+title: "bug: "
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -21,8 +21,9 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - OS: [e.g. iOS]
- - Editor version: [e.g. chrome, safari]
+
+- OS: [e.g. iOS]
+- Editor version: [e.g. chrome, safari]
 
 **Additional context**
 Add any other context about the problem here.

--- a/playwright-tests/pages/configPage.js
+++ b/playwright-tests/pages/configPage.js
@@ -49,7 +49,7 @@ export class ConfigPage {
 
     // Code Block Elements
     this.addBlocktoLastSandwichButton = page
-      .locator("anim-block")
+      .getByTestId("action-block")
       .filter({ hasText: "End" })
       .locator("action-placeholder div")
       .first();

--- a/playwright-tests/tests/blocksTests.spec.js
+++ b/playwright-tests/tests/blocksTests.spec.js
@@ -34,7 +34,7 @@ test.describe("Issues", () => {
     await configPage.addCodeBlock();
     await configPage.selectAllActions();
     await page
-      .locator("anim-block")
+      .getByTestId("action-block")
       .filter({ hasText: 'Code preview: print("hello")' })
       .getByRole("button")
       .nth(2)

--- a/src/renderer/main/_actions/move.action.ts
+++ b/src/renderer/main/_actions/move.action.ts
@@ -1,16 +1,12 @@
 import { get, writable, type Writable } from "svelte/store";
 import { GridAction, GridEvent } from "../../runtime/runtime";
-import {
-  dropActions,
-  removeActions,
-  syncWithGrid,
-} from "../../runtime/operations";
+import { dropActions } from "../../runtime/operations";
 
 export const draggedActions: Writable<GridAction[]> = writable([]);
 export type DropTarget = { event: GridEvent; index: number };
 export const dropEventTarget: Writable<DropTarget> = writable();
 
-function getDraggedActions(action: GridAction): GridAction[] {
+function getTargetActions(action: GridAction): GridAction[] {
   const actions: GridAction[] = [];
   const event = action.parent as GridEvent;
   let index = event.config.findIndex((e) => e.id === action.id);
@@ -36,11 +32,10 @@ function getDraggedActions(action: GridAction): GridAction[] {
   return actions;
 }
 
-function getDraggedBlocks(actions: GridAction[]): HTMLElement[] {
+function getTargetBlocks(actions: GridAction[]): HTMLElement[] {
   const dragged = actions
     .map((action) => document.querySelector(`[drag-id="${action.id}"]`))
     .filter((el): el is HTMLElement => el !== null);
-
   return dragged as HTMLElement[];
 }
 
@@ -72,7 +67,7 @@ export function draggable(node: HTMLElement, params: DragParameters) {
   let threshold = params.treshold ?? 15;
   let initPos: { x: number; y: number };
   let isDragged = false;
-  let dragged: HTMLElement[] = [];
+  let targetBlocks: HTMLElement[] = [];
   let movable = params.movable ?? true;
   node.setAttribute("drag-id", params.action.id);
 
@@ -80,14 +75,10 @@ export function draggable(node: HTMLElement, params: DragParameters) {
 
   function handleDragStart(x: number, y: number) {
     isDragged = true;
-    initPos = { x, y };
-    //for (const block of dragged) {
-    //  block.style.opacity = `0.5`;
-    //}
-    const actions = getDraggedActions(params.action);
+    const actions = getTargetActions(params.action);
     draggedActions.set(actions);
-    dragged = getDraggedBlocks(actions);
-    cursor = createDragCursor(dragged);
+    initPos = { x, y };
+    cursor = createDragCursor(targetBlocks);
     document.body.append(cursor);
   }
 
@@ -101,19 +92,14 @@ export function draggable(node: HTMLElement, params: DragParameters) {
       );
     }
 
-    //for (const block of dragged) {
-    //  block.style.opacity = `1.0`;
-    //}
-
     isDragged = false;
-    dragged = [];
     draggedActions.set([]);
     cursor.remove();
   }
 
   function handleMouseDown(e: MouseEvent) {
     const target = e.target as HTMLElement;
-    if (e.target !== e.currentTarget) {
+    if (target !== e.currentTarget) {
       return;
     }
 
@@ -121,13 +107,27 @@ export function draggable(node: HTMLElement, params: DragParameters) {
       return;
     }
 
-    handleDragStart(e.clientX, e.clientY);
+    const actions = getTargetActions(params.action);
+    targetBlocks = getTargetBlocks(actions);
+
+    for (const block of targetBlocks) {
+      block.style.opacity = `0.5`;
+    }
+
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseUp);
   }
 
   function handleMouseUp(e: MouseEvent) {
-    handleDragEnd(e);
+    if (isDragged) {
+      handleDragEnd(e);
+    }
+
+    for (const block of targetBlocks) {
+      block.style.opacity = `1.0`;
+    }
+    targetBlocks = [];
+
     document.removeEventListener("mousemove", handleMouseMove);
     document.removeEventListener("mouseup", handleMouseUp);
   }
@@ -138,12 +138,14 @@ export function draggable(node: HTMLElement, params: DragParameters) {
       cursor.style.top = `${e.clientY}px`;
       cursor.style.opacity = `1`;
 
-      //const distance = Math.abs(e.clientY - initPos.y);
-      //const normalized = Math.min(distance, threshold) / threshold;
-      //for (const block of dragged) {
-      //  block.style.opacity = `${0.5 - normalized * 0.3}`;
-      //}
-      //cursor.style.opacity = `${normalized === 1 ? "0.8" : "0"}`;
+      const distance = Math.abs(e.clientY - initPos.y);
+      const normalized = Math.min(distance, threshold) / threshold;
+      for (const block of targetBlocks) {
+        block.style.opacity = `${0.5 - normalized * 0.3}`;
+      }
+      cursor.style.opacity = `${normalized === 1 ? "0.8" : "0"}`;
+    } else {
+      handleDragStart(e.clientX, e.clientY);
     }
   }
 }

--- a/src/renderer/main/panels/configuration/ActionList.svelte
+++ b/src/renderer/main/panels/configuration/ActionList.svelte
@@ -147,7 +147,7 @@
         $event.config[index + 1]?.indentation === action.indentation &&
         $appSettings.persistent.actionHelperText}
 
-      <anim-block
+      <div
         animate:flip={{ duration: 300, easing: eases.backOut }}
         in:fade|global={{ delay: 0 }}
       >
@@ -179,7 +179,7 @@
         {:else}
           <SeparatorLine target={{ event: event, index: index + 1 }} />
         {/if}
-      </anim-block>
+      </div>
     {/each}
   </ul>
 

--- a/src/renderer/main/panels/configuration/ActionList.svelte
+++ b/src/renderer/main/panels/configuration/ActionList.svelte
@@ -93,6 +93,8 @@
       selected_actions.set(event.config);
     }
   }
+
+  $: console.log($event.config.map((e) => e.id));
 </script>
 
 <div class="flex flex-col h-full w-full overflow-hidden gap-2">

--- a/src/renderer/main/panels/configuration/ActionList.svelte
+++ b/src/renderer/main/panels/configuration/ActionList.svelte
@@ -93,8 +93,6 @@
       selected_actions.set(event.config);
     }
   }
-
-  $: console.log($event.config.map((e) => e.id));
 </script>
 
 <div class="flex flex-col h-full w-full overflow-hidden gap-2">

--- a/src/renderer/main/panels/configuration/ActionList.svelte
+++ b/src/renderer/main/panels/configuration/ActionList.svelte
@@ -148,6 +148,7 @@
         $appSettings.persistent.actionHelperText}
 
       <div
+        data-testid="action-block"
         animate:flip={{ duration: 300, easing: eases.backOut }}
         in:fade|global={{ delay: 0 }}
       >

--- a/src/renderer/runtime/runtime.ts
+++ b/src/renderer/runtime/runtime.ts
@@ -601,8 +601,12 @@ export class GridEvent extends RuntimeNode<EventData> {
         actions.map((e) => e.toLua()).join("").length >=
       0
     ) {
-      this.config.splice(index, 0, ...actions);
-      this.config = this.config; //TODO: Is there a better solution? Needed for reactivity
+      // Create a new array reference to trigger Svelte reactivity
+      this.config = [
+        ...this.config.slice(0, index),
+        ...actions,
+        ...this.config.slice(index),
+      ];
       actions.forEach((e) => ((e as any).parent = this));
       return Promise.resolve({
         value: true,

--- a/src/renderer/runtime/runtime.ts
+++ b/src/renderer/runtime/runtime.ts
@@ -922,7 +922,6 @@ export class GridEvent extends RuntimeNode<EventData> {
 
   // Setters
   private set config(value: Array<GridAction>) {
-    const temp = this.config;
     this.setField("config", value);
   }
 


### PR DESCRIPTION
Closes #936 

Reimplemented and added new animations:

- Re-added half-transparency when clicking action block
- Added distance based transparency effect when dragging an action block drom its place (visible when done slowly)
- Re-added transparency for original action block on drag
- Re-added transparency for dragged items
- Re-added list reordering animation