### PR TITLE
1022 bug incorrent active change is triggered when naviagting between events after successful store operation

### DIFF
--- a/playwright-tests/pages/configPage.js
+++ b/playwright-tests/pages/configPage.js
@@ -1,8 +1,11 @@
 import { blocks } from "../data/actionBlockLocators";
+import KeyboardActions from "../keyboardActions";
 
 export class ConfigPage {
   constructor(page) {
     this.page = page;
+
+    this.keyboardActions = new KeyboardActions(page);
 
     // Common Locators
     this.selectAllCheckbox = page.getByTestId("select_all");
@@ -231,11 +234,8 @@ export class ConfigPage {
     await this.page.getByText("Synced with Grid!").click();
     await this.codeblockInput.click({ clickCount: 1 });
 
-    const isMac = process.platform === "darwin";
-    const selectAllShortcut = isMac ? "Meta+A" : "Control+A";
+    await this.keyboardActions.selectAll();
 
-    await this.codeblockInput.press(selectAllShortcut);
-    await this.page.waitForTimeout(400);
     await this.codeblockInput.type(code);
   }
 

--- a/playwright-tests/tests/blocksTests.spec.js
+++ b/playwright-tests/tests/blocksTests.spec.js
@@ -49,16 +49,16 @@ test.describe("Issues", () => {
 
   // https://github.com/intechstudio/grid-editor/issues/1022
   test("Code block saving the stored changes", async ({ page }) => {
-    const text = "print('stored codeblock')";
+    const storedInput = "print('stored codeblock')";
     await configPage.removeAllActions();
-    await configPage.addAndEditCodeBlock(text);
+    await configPage.addAndEditCodeBlock(storedInput);
     await configPage.commitCode();
     await configPage.closeCode();
     await modulePage.storeConfig();
     await configPage.selectElementEvent("Setup");
     await configPage.selectElementEvent("Button");
 
-    const preText = page.locator("#cfg-0").getByText(text); // should find codeblock with hello
+    const preText = page.locator("#cfg-0").getByText(storedInput); // should find codeblock with the sored filed
     await expect(preText).toBeVisible();
   });
 

--- a/playwright-tests/tests/blocksTests.spec.js
+++ b/playwright-tests/tests/blocksTests.spec.js
@@ -45,9 +45,23 @@ test.describe("Issues", () => {
 
     const preText = await page.locator("#cfg-0").getByText(expectedText); // should find codeblock with hello
     await expect(preText).toBeVisible();
-
-    //TODO refactor, with contains(), it slow now
   });
+
+  // https://github.com/intechstudio/grid-editor/issues/1022
+  test("Code block saving the stored changes", async ({ page }) => {
+    const text = "print('stored codeblock')";
+    await configPage.removeAllActions();
+    await configPage.addAndEditCodeBlock(text);
+    await configPage.commitCode();
+    await configPage.closeCode();
+    await modulePage.storeConfig();
+    await configPage.selectElementEvent("Setup");
+    await configPage.selectElementEvent("Button");
+
+    const preText = page.locator("#cfg-0").getByText(text); // should find codeblock with hello
+    await expect(preText).toBeVisible();
+  });
+
   test("MIDI NRPN showes the converted value after switch element", async ({
     page,
   }) => {

--- a/src/renderer/main/modals/Monaco.svelte
+++ b/src/renderer/main/modals/Monaco.svelte
@@ -31,7 +31,7 @@
   import { beforeUpdate, afterUpdate, onMount } from "svelte";
   import { appSettings } from "../../runtime/app-helper.store";
   import { clickOutside } from "../_actions/click-outside.action";
-  import { syncWithGrid } from "../../runtime/operations";
+  import { syncWithGrid, updateAction } from "../../runtime/operations";
 
   export let monaco_action: GridAction;
 
@@ -183,13 +183,19 @@
   });
 
   async function handleCommitClicked() {
-    $monaco_action.script = GridScript.compressScript(editor.getValue());
-    $monaco_action.name =
-      name !== $monaco_action?.information.displayName ? name : undefined;
-    commited.name = $monaco_action.name;
-    commited.script = $monaco_action.script;
-    commitEnabled = false;
-    syncWithGrid(monaco_action);
+    updateAction(
+      monaco_action,
+      new ActionData(
+        monaco_action.short,
+        GridScript.compressScript(editor.getValue()),
+        name !== $monaco_action?.information.displayName ? name : undefined
+      ),
+      true
+    ).then(() => {
+      commited.name = $monaco_action.name;
+      commited.script = $monaco_action.script;
+      commitEnabled = false;
+    });
   }
 
   onDestroy(() => {


### PR DESCRIPTION
**Describe the bug**
Active change overlay is incorrectly triggered, and code is seemingly reverted in editor, however on the module the correct code is stored! 

**To Reproduce**
Steps to reproduce the behavior:

1. Connect a real module, with cleared configuration.
2. Navigate to the Setup event of the System element
3. Add the following statement to the codeblock: print(123)
4. Commit the code
5. Store the changes
6. Navigate to the Utility event (The bug is now triggered, active change is shown on Setup event)
7. Navigate back to the Setup event: The code is reverted to what it was before making the changes

**Expected behavior**
Stored change should be displayed, any previous state should be removed from runtime!

**Environment (please complete the following information):**

- OS: ubuntu
- Editor version: v1.5.3 (release)

https://github.com/user-attachments/assets/daff7028-227b-4eb2-b3b5-c8571c03f258