### PR TITLE
SUKU fixed line editor suggestion scopes

### DIFF
--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -117,8 +117,12 @@
 
   async function open_monaco() {
     const event = config.parent as GridEvent;
-    const element = event.parent as GridElement;
-    monaco_elementtype.set(element.type);
+    const restrictScopeTo = event.parent as GridElement;
+    monaco_elementtype.set(
+      restrictScopeTo == ElementType.FADER
+        ? ElementType.POTMETER
+        : restrictScopeTo,
+    );
     modal.show({
       component: Monaco,
       options: { snap: "middle", disableClickOutside: true },

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -6,7 +6,7 @@
   // Component for the untoggled "header" of the component
   import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
   export const header = RegularActionBlockFace;
-
+  import { ElementType } from "@intechstudio/grid-protocol";
   // config descriptor parameters
   export const information: ActionBlockInformation = {
     short: "cb",
@@ -116,8 +116,7 @@
   }
 
   async function open_monaco() {
-    const event = config.parent as GridEvent;
-    const restrictScopeTo = event.parent as GridElement;
+    const restrictScopeTo = config.parent.getInfo().element.type;
     monaco_elementtype.set(
       restrictScopeTo == ElementType.FADER
         ? ElementType.POTMETER

--- a/src/renderer/config-blocks/VarGlobal.svelte
+++ b/src/renderer/config-blocks/VarGlobal.svelte
@@ -50,6 +50,8 @@
       validationError: validationError,
     });
   }
+
+  let elementType = config.parent.getInfo().element.type;
 </script>
 
 <container>
@@ -61,6 +63,7 @@
       preProcessor={(script) => script}
       postProcessor={(script) => script}
       availableCharacters={$event.getAvailableChars()}
+      restrictScopeTo={elementType}
       on:input={handleUpdateAction}
       on:change={() => dispatch("sync")}
     />

--- a/src/renderer/config-blocks/VarLocals.svelte
+++ b/src/renderer/config-blocks/VarLocals.svelte
@@ -58,17 +58,19 @@
   function postProcessor(script: string): string {
     return `local ${script}`;
   }
+
+  let elementType = config.parent.getInfo().element.type;
 </script>
 
 <container>
   <div class="flex flex-col gap-2 w-full px-2 py-4 pointer-events-auto">
     <span class="text-white text-sm">Local Variables:</span>
-
     <VariableManager
       {script}
       {preProcessor}
       {postProcessor}
       availableCharacters={$event.getAvailableChars()}
+      restrictScopeTo={elementType}
       on:input={handleUpdateAction}
       on:change={() => dispatch("sync")}
     />

--- a/src/renderer/config-blocks/VarSelf.svelte
+++ b/src/renderer/config-blocks/VarSelf.svelte
@@ -63,6 +63,8 @@
     const rightSide = split.slice(1, split.length).join("").trim();
     return `${leftSide}=${rightSide}`;
   }
+
+  let elementType = config.parent.getInfo().element.type;
 </script>
 
 <container>
@@ -74,6 +76,7 @@
       {preProcessor}
       {postProcessor}
       availableCharacters={$event.getAvailableChars()}
+      restrictScopeTo={elementType}
       on:input={handleUpdateAction}
       on:change={() => dispatch("sync")}
     />

--- a/src/renderer/config-blocks/headers/ConditionElseIfFace.svelte
+++ b/src/renderer/config-blocks/headers/ConditionElseIfFace.svelte
@@ -47,6 +47,7 @@
         on:change={() => dispatch("sync")}
         value={scriptSegment}
         availableCharacters={$config.parent.getAvailableChars()}
+        restrictScopeTo={$config.parent.getInfo().element.type}
       />
     </div>
   </div>

--- a/src/renderer/config-blocks/headers/ConditionIfFace.svelte
+++ b/src/renderer/config-blocks/headers/ConditionIfFace.svelte
@@ -47,6 +47,7 @@
         on:change={() => dispatch("sync")}
         value={scriptSegment}
         availableCharacters={$config.parent.getAvailableChars()}
+        restrictScopeTo={$config.parent.getInfo().element.type}
       />
     </div>
     <span class="mx-3">Then</span>

--- a/src/renderer/config-blocks/headers/ForLoopHeader.svelte
+++ b/src/renderer/config-blocks/headers/ForLoopHeader.svelte
@@ -114,14 +114,13 @@
       class="bg-secondary my-auto mr-1 rounded flex items-center flex-grow h-full w-10"
       on:click|stopPropagation
     >
-      {#key displayValue}
-        <LineEditor
-          on:input={handleDisplayValueChange}
-          bind:value={displayValue}
-          on:change={() => dispatch("sync")}
-          availableCharacters={$config.parent.getAvailableChars()}
-        />
-      {/key}
+      <LineEditor
+        on:input={handleDisplayValueChange}
+        bind:value={displayValue}
+        on:change={() => dispatch("sync")}
+        availableCharacters={$config.parent.getAvailableChars()}
+        restrictScopeTo={$config.parent.getInfo().element.type}
+      />
     </div>
     <span>times</span>
     <div class="ml-auto flex items-center">

--- a/src/renderer/config-blocks/headers/FunctionStartFace.svelte
+++ b/src/renderer/config-blocks/headers/FunctionStartFace.svelte
@@ -47,6 +47,7 @@
         on:change={() => dispatch("sync")}
         value={scriptSegment}
         availableCharacters={$config.parent.getAvailableChars()}
+        restrictScopeTo={$config.parent.getInfo().element.type}
       />
     </div>
   </div>

--- a/src/renderer/main/user-interface/LineEditor.svelte
+++ b/src/renderer/main/user-interface/LineEditor.svelte
@@ -45,7 +45,11 @@
   onMount(() => {
     input_buffer = value;
 
-    monaco_elementtype.set(restrictScopeTo);
+    monaco_elementtype.set(
+      restrictScopeTo == ElementType.FADER
+        ? ElementType.POTMETER
+        : restrictScopeTo,
+    );
     editor = monaco_editor.create(monaco_block, {
       value: value,
       language: "intech_lua",


### PR DESCRIPTION
Fixed suggestion for line editor components in the following action blocks:
- Local
- Global
- Self
- Function
- Repeat

Repeat actionblock's internal logic is still buggy, that was not part of this fix!

Additionally fixed fader suggestions, previously suggestions were not available for Fader element in code-block