### PR TITLE
ProfileCloud configuration saving is now syntax safe

### DIFF
--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -200,6 +200,10 @@
       case "profile": {
         const page = runtime.findPage(ui.dx, ui.dy, ui.pagenumber);
         await page.load();
+        if (!page.isValid()) {
+          return Promise.reject(ProfileCloud.ErrorText.SYNTAX_ERROR);
+        }
+
         config.type = (page.parent as GridModule).type;
         config.configs = page.control_elements.map((element) => {
           return {
@@ -224,6 +228,10 @@
         );
         await element.load();
 
+        if (!element.isValid()) {
+          return Promise.reject(ProfileCloud.ErrorText.SYNTAX_ERROR);
+        }
+
         config.type = element.type;
         config.configs = {
           events: element.events.map((ev) => {
@@ -239,6 +247,9 @@
 
       case "snippet": {
         const selected = get(selected_actions);
+        if (selected.some((e) => !e.isValid())) {
+          return Promise.reject(ProfileCloud.ErrorText.SYNTAX_ERROR);
+        }
         if (selected.length === 0) {
           logger.set({
             type: "fail",

--- a/src/renderer/runtime/string-table.ts
+++ b/src/renderer/runtime/string-table.ts
@@ -12,5 +12,6 @@ export namespace ProfileCloud {
   export enum ErrorText {
     NO_DEVICE = `No device is connected.`,
     EMPTY_SNIPPET = "Snippet can not be created. No action block(s) selected.",
+    SYNTAX_ERROR = `Configuration with syntax error(s) can not be saved.`,
   }
 }


### PR DESCRIPTION
Closes #987 

See original ticket for more information.

Use PC build below. Syntax incorrect configurations are now can not be saved to PC.

Test with ~~stable~~ **nightly** PC version
