### PR TITLE
Fixed displayed character for international pound symbol

### DIFF
--- a/src/external/macro/map-de.json
+++ b/src/external/macro/map-de.json
@@ -218,7 +218,7 @@
   },
   {
     "info": "?????? Keyboard Int' #",
-    "display": "?????? Keyboard Int' #"
+    "display": "#"
   },
   {
     "info": "Semicolon",

--- a/src/external/macro/map-en.json
+++ b/src/external/macro/map-en.json
@@ -218,7 +218,7 @@
   },
   {
     "info": "?????? Keyboard Int' #",
-    "display": "?????? Keyboard Int' #"
+    "display": "\\"
   },
   {
     "info": "Semicolon",

--- a/src/external/macro/map-hu.json
+++ b/src/external/macro/map-hu.json
@@ -217,7 +217,7 @@
   },
   {
     "info": "?????? Keyboard Int' #",
-    "display": "?????? Keyboard Int' #"
+    "display": "ű"
   },
   {
     "info": "Semicolon",


### PR DESCRIPTION
Closes #886 

Displayed character for  0x32 HID (tested by changing keyboard layout in windows):
DE: # 
US: \\
HU: ű