### PR TITLE
Add Escape button to close every modal

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -287,23 +287,35 @@
 
   //Disable Context Menu
   onMount(async () => {
-    document.addEventListener("contextmenu", function (event) {
-      event.preventDefault();
-    });
+    document.addEventListener("contextmenu", preventContextMenuEvent);
+    document.addEventListener("keyup", handleEscapePress);
     loaded = true;
     window.electron.appLoaded();
   });
 
   onDestroy(() => {
-    document.removeEventListener("contextmenu", function (event) {
-      event.preventDefault();
-    });
+    document.removeEventListener("contextmenu", preventContextMenuEvent);
+    document.removeEventListener("keyup", handleEscapePress);
   });
+
+  function preventContextMenuEvent(e) {
+    e.preventDefault();
+  }
 
   $: handleDisableAnimationsChange(
     $appSettings.persistent.disableAnimations,
     $reduced_motion_store,
   );
+
+  function handleEscapePress(e) {
+    if (e.key === "Escape") {
+      if ($modal) {
+        modal.close();
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+  }
 </script>
 
 {#if import.meta.env.VITE_BUILD_TARGET !== "web"}

--- a/src/renderer/main/panels/configuration/components/ActionPicker.svelte
+++ b/src/renderer/main/panels/configuration/components/ActionPicker.svelte
@@ -42,6 +42,13 @@
   let searchValue = "";
   let searchBar;
 
+  function handleEscapePress(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      handleClose();
+    }
+  }
+
   onMount(() => {
     referenceElement.addEventListener("click", handleReferenceElementClick);
     actionPickerTimestamp = Date.now();
@@ -49,6 +56,8 @@
     if (typeof focusSearchBar !== "undefined") {
       focusSearchBar();
     }
+
+    document.addEventListener("keyup", handleEscapePress);
   });
 
   // Clean up the event listener when the component is destroyed
@@ -62,6 +71,8 @@
       },
       mandatory: false,
     });
+
+    document.removeEventListener("keyup", handleEscapePress);
   });
 
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Pressing escape when any modal is active closes it. This requires extensive testing to make sure that the behaviour is the same as what the user expects. The affected modals:
CodeBlock -> Monaco
AddVirtualModule
DebugMonitor -> Export
UserAuthenticationModal
Feedback
Welcome