### PR TITLE
✨FEATURE: Replaced LineEditor to MeltInput in block rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20250321.1539",
-        "@intechstudio/grid-uikit": "1.20250406.1652",
+        "@intechstudio/grid-uikit": "1.20250406.1721",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
         "chokidar": "^3.5.3",
@@ -1955,9 +1955,9 @@
       "integrity": "sha512-CF3JiVPoFPCWkoIfdwqm7fvk63+drNzc0yYDE7kHn0E5tremJmGam7sGDClMnToEL2Zd+Wp2NHfTeRIAQaIeYQ=="
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20250406.1652",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250406.1652.tgz",
-      "integrity": "sha512-gRC3kmwjQg37TZKtd7xFxiG57wbT+Pjrs0jy8orlEGLF4R4R17HUxqXYSL9uzgPDwYlw/+Gj+uFMg8uZkxTV+w==",
+      "version": "1.20250406.1721",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250406.1721.tgz",
+      "integrity": "sha512-ATdmuEGIIGTqQZvFfDjxhTQvzD177mPlcq9hd4FLprcun9dHWfsShzI+G2GE/injfRQD9nFv387sQV/IN64ifA==",
       "dependencies": {
         "@melt-ui/svelte": "^0.83.0",
         "svelte": "^4.2.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20250321.1539",
-        "@intechstudio/grid-uikit": "1.20250331.1337",
+        "@intechstudio/grid-uikit": "1.20250406.1652",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
         "chokidar": "^3.5.3",
@@ -1955,9 +1955,9 @@
       "integrity": "sha512-CF3JiVPoFPCWkoIfdwqm7fvk63+drNzc0yYDE7kHn0E5tremJmGam7sGDClMnToEL2Zd+Wp2NHfTeRIAQaIeYQ=="
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20250331.1337",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250331.1337.tgz",
-      "integrity": "sha512-d0I9v5BAmHLeh7g7SOZLqwKmwzMQJmi3OsYyyG3rn1fG8OiQvVozZH8EkykpBBmqwRXDrIfi/8COMHJ/7CDodw==",
+      "version": "1.20250406.1652",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250406.1652.tgz",
+      "integrity": "sha512-gRC3kmwjQg37TZKtd7xFxiG57wbT+Pjrs0jy8orlEGLF4R4R17HUxqXYSL9uzgPDwYlw/+Gj+uFMg8uZkxTV+w==",
       "dependencies": {
         "@melt-ui/svelte": "^0.83.0",
         "svelte": "^4.2.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20250321.1539",
-        "@intechstudio/grid-uikit": "1.20250318.1500",
+        "@intechstudio/grid-uikit": "1.20250331.1337",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
         "chokidar": "^3.5.3",
@@ -1955,9 +1955,9 @@
       "integrity": "sha512-CF3JiVPoFPCWkoIfdwqm7fvk63+drNzc0yYDE7kHn0E5tremJmGam7sGDClMnToEL2Zd+Wp2NHfTeRIAQaIeYQ=="
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20250318.1500",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250318.1500.tgz",
-      "integrity": "sha512-tOL8D4RvfkvuJvPU1BMDSYq4z4GQDr3ZXF8gUkiCNPgz5wizJUXzdiAGfPb3n4rnPxmZpLql0bwJDSSDUhdc3A==",
+      "version": "1.20250331.1337",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250331.1337.tgz",
+      "integrity": "sha512-d0I9v5BAmHLeh7g7SOZLqwKmwzMQJmi3OsYyyG3rn1fG8OiQvVozZH8EkykpBBmqwRXDrIfi/8COMHJ/7CDodw==",
       "dependencies": {
         "@melt-ui/svelte": "^0.83.0",
         "svelte": "^4.2.12",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20250321.1539",
-    "@intechstudio/grid-uikit": "1.20250331.1337",
+    "@intechstudio/grid-uikit": "1.20250406.1652",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",
     "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20250321.1539",
-    "@intechstudio/grid-uikit": "1.20250318.1500",
+    "@intechstudio/grid-uikit": "1.20250331.1337",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",
     "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20250321.1539",
-    "@intechstudio/grid-uikit": "1.20250406.1652",
+    "@intechstudio/grid-uikit": "1.20250406.1721",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",
     "chokidar": "^3.5.3",

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -42,7 +42,7 @@
     name = value;
     //isEdit = false;
     nameChange = true;
-    console.log(name)
+    console.log(name);
     sendData(name);
   }
 
@@ -61,7 +61,7 @@
   let isEdit = false;
   let nameChange = false;
 
-  $: console.log(isEdit)
+  $: console.log(isEdit);
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { appSettings } from "./../../runtime/app-helper.store";
-  import LineEditor from "./../../main/user-interface/LineEditor.svelte";
   import { createEventDispatcher } from "svelte";
-  import { SvgIcon } from "@intechstudio/grid-uikit";
+  import { SvgIcon, MoltenInput } from "@intechstudio/grid-uikit";
   import { onMount } from "svelte";
   import { GridAction } from "../../runtime/runtime";
 
@@ -39,10 +38,11 @@
   });
 
   function handleNameChange(e) {
-    const { script } = e.detail;
-    name = script;
-    isEdit = false;
+    const { value } = e.detail;
+    name = value;
+    //isEdit = false;
     nameChange = true;
+    console.log(name)
     sendData(name);
   }
 
@@ -60,6 +60,8 @@
   let name: string;
   let isEdit = false;
   let nameChange = false;
+
+  $: console.log(isEdit)
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />
@@ -72,11 +74,11 @@
 >
   {#if isEdit}
     <div
-      class="bg-primary font-normal my-auto rounded flex items-center flex-grow h-full"
+      class="bg-primary font-normal my-auto rounded flex items-center flex-grow h-full pointer-events-auto"
       on:click|stopPropagation
     >
-      <LineEditor
-        value={name}
+      <MoltenInput
+        target={name}
         on:input={handleNameChange}
         on:change={() => dispatch("sync")}
         availableCharacters={$config.parent.getAvailableChars()}

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -37,13 +37,16 @@
         : config.information.displayName;
   });
 
-  function handleNameChange(e) {
+  function handleNameInput(e: any) {
     const { value } = e.detail;
     name = value;
-    //isEdit = false;
-    nameChange = true;
-    console.log(name);
     sendData(name);
+  }
+
+  function handleNameChange(e) {
+    isEdit = false;
+    nameChange = true;
+    dispatch("sync");
   }
 
   function handleKeyDown(e) {
@@ -60,44 +63,44 @@
   let name: string;
   let isEdit = false;
   let nameChange = false;
-
-  $: console.log(isEdit);
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<div
-  class="justify-between gap-2 w-full px-2 py-1 flex-row text-white flex items-center bg-secondary"
+<button
+  class="justify-between gap-2 w-full px-2 py-1 flex-row text-white flex items-center bg-secondary overflow-hidden"
   on:click={handleClick}
 >
   {#if isEdit}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
       class="bg-primary font-normal my-auto rounded flex items-center flex-grow h-full pointer-events-auto"
       on:click|stopPropagation
     >
       <MoltenInput
         target={name}
-        on:input={handleNameChange}
-        on:change={() => dispatch("sync")}
+        on:input={handleNameInput}
+        on:change={handleNameChange}
         availableCharacters={$config.parent.getAvailableChars()}
       />
     </div>
   {:else}
-    <span class="truncate"
-      >{typeof $config?.name === "undefined"
-        ? config.information.displayName
-        : $config.name}</span
-    >
+    <div class="w-0 flex-grow min-w-0 items-start text-left">
+      <span class="truncate block">
+        {typeof $config?.name === "undefined"
+          ? config.information.displayName
+          : $config.name}
+      </span>
+    </div>
   {/if}
 
   {#if $appSettings.persistent.editableBlockNames}
     <button
       on:click|stopPropagation={handleEditClicked}
-      class="cursor-pointer pointer-events-auto"
+      class="cursor-pointer pointer-events-auto hover:bg-black/25 flex w-fit h-fit p-1.5 rounded"
     >
       <SvgIcon iconPath="edit" fill="#FFF" width={13} height={13} />
     </button>
   {/if}
-</div>
+</button>

--- a/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
+++ b/src/renderer/config-blocks/headers/RegularActionBlockFace.svelte
@@ -3,13 +3,17 @@
   import { createEventDispatcher } from "svelte";
   import { SvgIcon, MoltenInput } from "@intechstudio/grid-uikit";
   import { onMount } from "svelte";
-  import { GridAction } from "../../runtime/runtime";
+  import { GridAction, GridEvent } from "../../runtime/runtime";
+  import { get } from "svelte/store";
+  import { selected_actions } from "../../runtime/user-input.store";
 
   const dispatch = createEventDispatcher();
 
   export let config: GridAction;
+  let event = config.parent as GridEvent;
 
   function handleClick(e) {
+    console.log("hmmm");
     dispatch("toggle");
   }
 
@@ -50,7 +54,7 @@
   }
 
   function handleKeyDown(e) {
-    if (e.key === "F2" && config.selected) {
+    if (e.key === "F2" && get(selected_actions).includes(config)) {
       isEdit = true;
     }
 
@@ -67,24 +71,20 @@
 
 <svelte:window on:keydown={handleKeyDown} />
 
-<button
-  class="justify-between gap-2 w-full px-2 py-1 flex-row text-white flex items-center bg-secondary overflow-hidden"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div
+  role="button"
+  tabindex="0"
+  class="justify-between gap-2 w-full px-2 py-1 flex-row text-white flex items-center bg-secondary overflow-hidden pointer-events-auto"
   on:click={handleClick}
 >
   {#if isEdit}
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div
-      class="bg-primary font-normal my-auto rounded flex items-center flex-grow h-full pointer-events-auto"
-      on:click|stopPropagation
-    >
-      <MoltenInput
-        target={name}
-        on:input={handleNameInput}
-        on:change={handleNameChange}
-        availableCharacters={$config.parent.getAvailableChars()}
-      />
-    </div>
+    <MoltenInput
+      target={name}
+      on:input={handleNameInput}
+      on:change={handleNameChange}
+      availableCharacters={$event.getAvailableChars()}
+    />
   {:else}
     <div class="w-0 flex-grow min-w-0 items-start text-left">
       <span class="truncate block">
@@ -98,9 +98,9 @@
   {#if $appSettings.persistent.editableBlockNames}
     <button
       on:click|stopPropagation={handleEditClicked}
-      class="cursor-pointer pointer-events-auto hover:bg-black/25 flex w-fit h-fit p-1.5 rounded"
+      class="cursor-pointer hover:bg-black/25 flex w-fit h-fit p-1.5 rounded"
     >
       <SvgIcon iconPath="edit" fill="#FFF" width={13} height={13} />
     </button>
   {/if}
-</button>
+</div>


### PR DESCRIPTION
Closes #1047 

See original ticket for details!

Added feature: Replaced input element type of LineEditor to MoltenInput when renaming a block. To enable element renaming, enable it in preferences under the General settings tab.