### PR TITLE
Handle uncaught page change exception

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -121,7 +121,12 @@
         break;
       }
       case "change-page": {
-        get(runtime_manager).active.runtime.change_page(data.num);
+        get(runtime_manager)
+          .active.runtime.change_page(data.num)
+          .catch((e) => {
+            //Silently handle exception if operation is not available
+            console.error(e);
+          });
         break;
       }
       case "persist-github-package": {

--- a/src/renderer/runtime/virtual-engine.ts
+++ b/src/renderer/runtime/virtual-engine.ts
@@ -275,7 +275,7 @@ export class ConnectionSimulator implements Readable<VirtualModule[]> {
           break;
         }
         default: {
-          reject("This operation is not implemented ye in virtual mode!");
+          reject("This operation is not implemented yet in virtual mode!");
         }
       }
     });


### PR DESCRIPTION
This is added for the active window package, which could schedule a page change command without a module being connected to the Editor.

To test, you must install the Active Window package, configure two separate application for the page change, and switch between them without a module being plugged in. No notification or banner should be shown.