### PR TITLE
🐛BUG: Fixed reverting to synced state and grid configuration sync

### DIFF
--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -68,7 +68,7 @@
     updateAction(
       action,
       new ActionData(action.short, action.synced, action.name),
-      false,
+      true,
     );
   }
 
@@ -95,9 +95,11 @@
   }
 
   function handleSendActionToGrid() {
-    if (!action.invalid) {
-      syncWithGrid(action);
+    if (!action.isValid()) {
+      return;
     }
+
+    syncWithGrid(action);
   }
 
   function handleToggle(e) {

--- a/src/renderer/runtime/operations.ts
+++ b/src/renderer/runtime/operations.ts
@@ -22,7 +22,6 @@ import {
 } from "./runtime";
 import { get } from "svelte/store";
 import { user_input } from "./user-input.store";
-import { Runtime } from "./string-table";
 
 function handleError(e: GridOperationResult) {
   //TODO: Better error handling


### PR DESCRIPTION
Closes #1018 

See bug description in original ticket!

The grid configuration syncing behaviour was fixed in the following way: 

- On change (clicking outside MeltCombo, etc.) the configuration is sent to module, if it is a valid config (no syntax error, no validation error). IMPORTANT, this may be broken in stable? This results in that the configuration on module is not present, only in editor. This is a worst case scenario, and may require a hotfix release.
- When an invalid action block is destroyed (due to being out of scope), it is reverted to last valid state, and sent to grid. This mechanic was broken, which resulted in the linked bug (#1018), and is fixed in this PR.