### PR TITLE
Run build on older Linux system to ensure lower glibc version

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-22.04, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -47,7 +47,9 @@ jobs:
           node-version: "18.16.1"
 
       - name: Install python setup-tools dependency
-        run: pip install setuptools --break-system-packages
+        run: pip install setuptools
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
 
       - name: Install libudev-dev (Linux only)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Running on ubuntu-latest, some systems showed the following error:

![image](https://github.com/user-attachments/assets/989da932-3a19-4e9d-aa3c-b095702372b3)

Running on older ubuntu seems to fix it.