### PR TITLE
✨FEATURE: Replaced send inmediate input to Monaco based editor

### DIFF
--- a/src/renderer/lib/monaco.ts
+++ b/src/renderer/lib/monaco.ts
@@ -38,7 +38,7 @@ const language_config = {
   ],
 };
 
-export const language = {
+const [lua, intech_lua] = Array(2).fill({
   defaultToken: "",
   tokenPostfix: ".lua",
   keywords: [
@@ -206,10 +206,11 @@ export const language = {
       ],
     ],
   },
-};
+});
 
 function initialize_language() {
   monaco_languages.register({ id: "intech_lua" });
+  monaco_languages.register({ id: "lua" });
 }
 
 function initialize_theme() {
@@ -268,7 +269,60 @@ type Range = {
 };
 
 function initialize_autocomplete() {
-  function createProposals(
+  function createLuaProposals(range: Range) {
+    let proposalList = [];
+    lua.functions = ["print"];
+
+    // Handle other general cases (mathfunctions, keywords, etc.)
+    for (const element of lua.mathfunctions) {
+      let proposalItem = {
+        label: "",
+        kind: monaco_languages.CompletionItemKind.Function,
+        documentation: "Documentation",
+        insertText: "",
+        range: range,
+      };
+
+      proposalItem.label = "math." + element;
+      proposalItem.insertText = "math." + element;
+      proposalList.push(proposalItem);
+    }
+
+    for (const element of lua.keywords) {
+      let proposalItem = {
+        label: "",
+        kind: monaco_languages.CompletionItemKind.Keyword,
+        documentation: "Documentation",
+        insertText: "",
+        range: range,
+      };
+
+      proposalItem.label = element;
+      proposalItem.insertText = element;
+
+      proposalList.push(proposalItem);
+    }
+
+    for (const element of lua.functions) {
+      if (proposalList.find((e) => e.label === element)) {
+        continue;
+      }
+
+      let proposalItem = {
+        kind: monaco_languages.CompletionItemKind.Function,
+        documentation: "Documentation",
+        range: range,
+        label: element,
+        insertText: element + "()",
+      };
+
+      proposalList.push(proposalItem);
+    }
+
+    return proposalList;
+  }
+
+  function createIntechLuaProposals(
     range: Range,
     model: monaco_editor.ITextModel,
     position: Position,
@@ -284,10 +338,10 @@ function initialize_autocomplete() {
         : instance.restrictScope;
 
     let proposalList = [];
-    language.functions = ["print"];
+    intech_lua.functions = ["print"];
 
     // Handle other general cases (mathfunctions, keywords, etc.)
-    for (const element of language.mathfunctions) {
+    for (const element of intech_lua.mathfunctions) {
       let proposalItem = {
         label: "",
         kind: monaco_languages.CompletionItemKind.Function,
@@ -301,7 +355,7 @@ function initialize_autocomplete() {
       proposalList.push(proposalItem);
     }
 
-    for (const element of language.keywords) {
+    for (const element of intech_lua.keywords) {
       let proposalItem = {
         label: "",
         kind: monaco_languages.CompletionItemKind.Keyword,
@@ -368,7 +422,7 @@ function initialize_autocomplete() {
       }
     }
 
-    for (const element of language.functions) {
+    for (const element of intech_lua.functions) {
       if (proposalList.find((e) => e.label === element)) {
         continue;
       }
@@ -414,7 +468,23 @@ function initialize_autocomplete() {
       }
 
       return {
-        suggestions: createProposals(range, model, position, prefix),
+        suggestions: createIntechLuaProposals(range, model, position, prefix),
+      };
+    },
+  });
+
+  monaco_languages.registerCompletionItemProvider("lua", {
+    provideCompletionItems: function (model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: Range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+
+      return {
+        suggestions: createLuaProposals(range),
       };
     },
   });
@@ -423,12 +493,12 @@ function initialize_autocomplete() {
 function initialize_highlight() {
   grid.lua_function_to_human_map().forEach((value, key) => {
     //AUTOCOMPLETE FUNCTIONS
-    language.functions.push(value);
+    intech_lua.functions.push(value);
   });
 
   grid.lua_function_forbiddens().forEach((value) => {
     //FORBIDDEN IDENTIFIERS
-    language.forbiddens.push(value);
+    intech_lua.forbiddens.push(value);
   });
 }
 
@@ -451,7 +521,7 @@ function initialize_hover() {
 }
 
 function initialize_grammar() {
-  monaco_languages.setMonarchTokensProvider("intech_lua", language);
+  monaco_languages.setMonarchTokensProvider("intech_lua", intech_lua);
   monaco_languages.setLanguageConfiguration("intech_lua", language_config);
 }
 

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -24,6 +24,7 @@
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { Grid } from "../../../lib/_utils";
   import DebugTextList from "./DebugTextList.svelte";
+  import SendInmediate from "./SendInmediate.svelte";
 
   let event: GridEvent;
 
@@ -194,15 +195,7 @@
       <MoltenPushButton text="Show Code" click={handleShowCode} />
     </div>
   </div>
-  <div class="grid grid-cols-[1fr_auto] gap-2 items-center">
-    <MoltenInput bind:target={immediateCommand} />
-    <MoltenPushButton
-      click={() => {
-        runtime_manager.LUAExecImmediate(0, 0, immediateCommand);
-      }}
-      text="Immediate"
-    />
-  </div>
+  <SendInmediate />
 
   <div class="flex felx-row gap-2 flex-wrap text-white items-center my-4">
     <MoltenPushButton click={clearDebugtext} text="Clear" />

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -11,7 +11,7 @@
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
       value: "",
-      language: "intech_lua",
+      language: "lua",
       theme: "my-theme",
       fontSize: $appSettings.persistent.fontSize,
       folding: false,

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { MoltenPushButton } from "@intechstudio/grid-uikit";
+  import { runtime_manager } from "../../../runtime/runtime-manager.store";
+  import { onMount } from "svelte";
+  import { MonacoEditor } from "../../../lib/monaco";
+  import { appSettings } from "../../../runtime/app-helper.store";
+
+  let monacoElement: HTMLElement;
+  let editor: MonacoEditor.CustomCodeEditor;
+
+  onMount(() => {
+    editor = MonacoEditor.create(monacoElement, {
+      value: "",
+      language: "intech_lua",
+      theme: "my-theme",
+      fontSize: $appSettings.persistent.fontSize,
+      folding: false,
+      renderLineHighlight: "none",
+      contextmenu: false,
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+      wordWrap: "on",
+      suggest: {
+        showIcons: false,
+        showWords: true,
+      },
+      minimap: {
+        enabled: false,
+      },
+      lineNumbers: "off",
+    });
+  });
+
+  function handleSendInmediateclicked() {
+    const value = editor.getValue();
+    runtime_manager.LUAExecImmediate(0, 0, value);
+  }
+</script>
+
+<div class="grid grid-cols-[1fr_auto] gap-2 items-center h-32">
+  <div
+    bind:this={monacoElement}
+    class="flex w-full h-full border border-black"
+  />
+  <MoltenPushButton click={handleSendInmediateclicked} text="Immediate" />
+</div>


### PR DESCRIPTION
Closes #1132 

Replaced send inmediates input field to a monaco based mini-editor in Debug Monitor. 

Added simple LUA language for send immediate auto suggestions. This panel now does not suggest Grid specific functions.

**NOTE:** Monaco editor should still suggest the same Grid + LUA specific functions correctly!