### PR TITLE
🐛BUG: Fixed visual bug of MeltSelect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20250630.1305",
-        "@intechstudio/grid-uikit": "1.20250625.900",
+        "@intechstudio/grid-uikit": "1.20250702.1711",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
         "axios": "^1.9.0",
@@ -2317,9 +2317,9 @@
       "integrity": "sha512-jPoe3aZPa7GMnbilO3UZhhpMrFW4j2OaJRrBDoS/lIc9EZSkpMC3a1NyV20DCTPVxmIjFk48o+1IZVXK+okkQQ=="
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20250625.900",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250625.900.tgz",
-      "integrity": "sha512-+tN6eQrvQ/rUwGu+3MskytX6YBZUw/6o/OxPebDjmRcEfPEJmpf49GTmpXOuQXuOC5ZU48va6M1P8BAqQ4BHMg==",
+      "version": "1.20250702.1711",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250702.1711.tgz",
+      "integrity": "sha512-40bxkWYH3eKb3lIaQokdYXdoDR3C58sZWmkM9SZyFU93iYMZQ1wrIjq9Shqm2m4e2mR3p8adYo/zpeLyQ8qadQ==",
       "dependencies": {
         "@melt-ui/svelte": "^0.86.6",
         "svelte": "^4.2.12",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20250630.1305",
-    "@intechstudio/grid-uikit": "1.20250625.900",
+    "@intechstudio/grid-uikit": "1.20250702.1711",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",
     "axios": "^1.9.0",


### PR DESCRIPTION
Closes #1173 

See original ticket for bug description!

Removed event propagation for MoltenTooltip in grid-uikit.
Instant tooltip now automatically closes, when the reference element is clicked (as in NavTabs)
These changes affect all tooltips, including the tooltip with buttons (as seen on Clear button)
Checking if tooltip behaviour is intact might be necessary.