### PR TITLE
Add report firebase website, push playwright result there instead of git

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,6 +5,7 @@
   "targets": {
     "grid-editor-web": {
       "hosting": {
+        "grid-editor": ["grid-editor-web"],
         "playwright-preview": ["grid-playwright-report"]
       }
     }

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,12 @@
 {
   "projects": {
     "default": "grid-editor-web"
+  },
+  "targets": {
+    "grid-editor-web": {
+      "hosting": {
+        "playwright-preview": ["grid-playwright-report"]
+      }
+    }
   }
 }

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -29,6 +29,7 @@ jobs:
           channelId: live
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
           projectId: grid-editor-web
+          target: grid-editor
 
       - name: Deploy to Firebase Hosting on pull request
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
@@ -37,4 +38,5 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
           projectId: grid-editor-web
+          target: grid-editor
           expires: 30d

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,17 +49,19 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - name: Derive Channel ID from Commit SHA
-        id: derive_channel
-        run: |
-          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
-          echo "channel=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:
           name: playwright-report
           path: playwright-report/
-      - name: Deploy to Firebase Hosting (Reports Site)
+      - name: Derive Channel ID from Commit SHA
+        if: ${{ github.event_name == 'push' }}
+        id: derive_channel
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
+          echo "channel=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+      - name: Report to Firebase Hosting on Push
+        if: ${{ github.event_name == 'push' }}
         id: firebase_deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -68,6 +70,16 @@ jobs:
           projectId: grid-editor-web
           target: playwright-preview
           channelId: ${{ steps.derive_channel.outputs.channel }}
+          expires: 7d
+      - name: Report to Firebase Hosting on Pull Request
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        id: firebase_deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
+          projectId: grid-editor-web
+          target: playwright-preview
           expires: 7d
 
       - name: Output Preview URL

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,16 +47,13 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      # Unique URL path for each workflow run attempt
-      HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:
           name: playwright-report
-          path: ${{ env.HTML_REPORT_URL_PATH }}
+          path: playwright-report/
       - name: Deploy to Firebase Hosting (Reports Site)
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,7 +71,7 @@ jobs:
           projectId: grid-editor-web
           target: playwright-preview
           channelId: ${{ steps.derive_channel.outputs.channel }}
-          expires: 7d
+          expires: 1d
       - name: Output Preview URL
         if: ${{ github.event_name == 'push' }}
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,45 +51,23 @@ jobs:
       # Unique URL path for each workflow run attempt
       HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
     steps:
-      - name: Checkout GitHub Pages Branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-      - name: Set Git User
-        # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:
           name: playwright-report
           path: ${{ env.HTML_REPORT_URL_PATH }}
-      - name: Push HTML Report
-        timeout-minutes: 3
-        # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
-        # this is necessary when this job is running at least twice at the same time (e.g. through two pushes at the same time)
-        run: |
-          git add .
-          git commit -m "workflow: add HTML report for run-id ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
+      - name: Deploy to Firebase Hosting (Reports Site)
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
+          projectId: grid-editor-web
+          target: playwright-preview
+          expires: 7d
 
-          while true; do
-            git pull --rebase
-            if [ $? -ne 0 ]; then
-              echo "Failed to rebase. Please review manually."
-              exit 1
-            fi
-
-            git push
-            if [ $? -eq 0 ]; then
-              echo "Successfully pushed HTML report to repo."
-              exit 0
-            fi
-          done
-      - name: Output Report URL as Worfklow Annotation
+      - name: Output Preview URL
         run: |
-          FULL_HTML_REPORT_URL=https://intechstudio.github.io/grid-editor/$HTML_REPORT_URL_PATH
-          echo "::notice title=📋 Published Playwright Test Report::$FULL_HTML_REPORT_URL"
+          echo "::notice title=📋 Playwright Report Preview::${{ steps.firebase_deploy.outputs.details_url }}"
 
 # # HEADED MODE
 #  name: Playwright Tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,6 +64,7 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
           projectId: grid-editor-web
           target: playwright-preview
+          channelId: pr-${{ github.event.pull_request.number }}
           expires: 7d
 
       - name: Output Preview URL

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,7 @@ on:
       - "**"
     tags-ignore:
       - "*"
+  pull_request:
 
 # only one workflow is running at the same time for each branch
 # concurrency:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,6 +51,7 @@ jobs:
       # Unique URL path for each workflow run attempt
       HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
     steps:
+      - uses: actions/checkout@v4
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,13 +55,13 @@ jobs:
           name: playwright-report
           path: playwright-report/
       - name: Deploy to Firebase Hosting (Reports Site)
+        id: firebase_deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
           projectId: grid-editor-web
           target: playwright-preview
-          channelId: pr-${{ github.event.pull_request.number }}
           expires: 7d
 
       - name: Output Preview URL

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,6 +49,11 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+      - name: Derive Channel ID from Commit SHA
+        id: derive_channel
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
+          echo "channel=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
       - name: Download zipped HTML report
         uses: actions/download-artifact@v4
         with:
@@ -62,6 +67,7 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GRID_EDITOR_WEB }}"
           projectId: grid-editor-web
           target: playwright-preview
+          channelId: ${{ steps.derive_channel.outputs.channel }}
           expires: 7d
 
       - name: Output Preview URL

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -84,7 +84,6 @@ jobs:
           projectId: grid-editor-web
           target: playwright-preview
           expires: 7d
-
 # # HEADED MODE
 #  name: Playwright Tests
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,9 +71,12 @@ jobs:
           target: playwright-preview
           channelId: ${{ steps.derive_channel.outputs.channel }}
           expires: 7d
+      - name: Output Preview URL
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "::notice title=📋 Playwright Report Preview::${{ steps.firebase_deploy.outputs.details_url }}"
       - name: Report to Firebase Hosting on Pull Request
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-        id: firebase_deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
@@ -81,10 +84,6 @@ jobs:
           projectId: grid-editor-web
           target: playwright-preview
           expires: 7d
-
-      - name: Output Preview URL
-        run: |
-          echo "::notice title=📋 Playwright Report Preview::${{ steps.firebase_deploy.outputs.details_url }}"
 
 # # HEADED MODE
 #  name: Playwright Tests

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "hosting": [
     {
-      "target": "default",
+      "target": "grid-editor",
       "public": "dist-web",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
       "rewrites": [

--- a/firebase.json
+++ b/firebase.json
@@ -1,12 +1,20 @@
 {
-  "hosting": {
-    "public": "dist-web",
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/src/renderer/index.html"
-      }
-    ],
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
-  }
+  "hosting": [
+    {
+      "target": "default",
+      "public": "dist-web",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/src/renderer/index.html"
+        }
+      ]
+    },
+    {
+      "target": "playwright-preview",
+      "public": "playwright-report",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    }
+  ]
 }


### PR DESCRIPTION
Move playwright report publication to Firebase, freeing up the Github Pages solution.
After everyone merged this change, do not forget to delete and **purge** the gh-pages branch that currently holds the results.