### PR TITLE
Look for category name in action picker search as well

### DIFF
--- a/src/renderer/main/panels/configuration/components/ActionPicker.svelte
+++ b/src/renderer/main/panels/configuration/components/ActionPicker.svelte
@@ -347,7 +347,12 @@
           ).toLocaleLowerCase();
 
           for (const term of searchTerms) {
-            if (name.indexOf(term.toLocaleLowerCase()) === -1) {
+            if (
+              name.indexOf(term.toLocaleLowerCase()) === -1 &&
+              option.category
+                .toLocaleLowerCase()
+                .indexOf(term.toLocaleLowerCase()) === -1
+            ) {
               return false;
             }
           }


### PR DESCRIPTION
Based on one point of https://github.com/intechstudio/grid-editor/issues/1137

The goal of this PR is to extend the search functionality of the action picker to also include the category of the actions, such as showing all Photoshop actions when any part of "photoshop" is in the search terms.