### PR TITLE
SUKU hardware address based led indexing implemented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.8",
       "hasInstallScript": true,
       "dependencies": {
-        "@intechstudio/grid-protocol": "1.20250630.1305",
+        "@intechstudio/grid-protocol": "1.20250804.1407",
         "@intechstudio/grid-uikit": "1.20250728.1324",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
@@ -2315,9 +2315,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@intechstudio/grid-protocol": {
-      "version": "1.20250630.1305",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20250630.1305.tgz",
-      "integrity": "sha512-jPoe3aZPa7GMnbilO3UZhhpMrFW4j2OaJRrBDoS/lIc9EZSkpMC3a1NyV20DCTPVxmIjFk48o+1IZVXK+okkQQ=="
+      "version": "1.20250804.1407",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20250804.1407.tgz",
+      "integrity": "sha512-oO6caVhlNXpcQXp/D9j2ejRuIq74waSqmaqxVi5A0MWiJUq78mg3m2HVnrJVo7X/fWyiMd08o2UO5eCct6yS4w=="
     },
     "node_modules/@intechstudio/grid-uikit": {
       "version": "1.20250728.1324",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20250630.1305",
-        "@intechstudio/grid-uikit": "1.20250722.1402",
+        "@intechstudio/grid-uikit": "1.20250728.1324",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
         "axios": "^1.9.0",
@@ -2320,9 +2320,9 @@
       "integrity": "sha512-jPoe3aZPa7GMnbilO3UZhhpMrFW4j2OaJRrBDoS/lIc9EZSkpMC3a1NyV20DCTPVxmIjFk48o+1IZVXK+okkQQ=="
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20250722.1402",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250722.1402.tgz",
-      "integrity": "sha512-PsSuxClT+gtKuNiRD7VvR6oDdmT6hqImXZmcBrs5EdbEaibLaaADQVOlCzPp9qeC/fkGxVoJn/srsSrWMwIO0w==",
+      "version": "1.20250728.1324",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20250728.1324.tgz",
+      "integrity": "sha512-e/MBo3ExolDYPG6I/m9+A9lmZm3wYt5OEqDNntr8c+PF9AG0PFgZDT6drMF6I6yXCGtP1CvIZRY1LZkaU996RQ==",
       "dependencies": {
         "@melt-ui/svelte": "^0.86.6",
         "color-convert": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20250630.1305",
-    "@intechstudio/grid-uikit": "1.20250722.1402",
+    "@intechstudio/grid-uikit": "1.20250728.1324",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",
     "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vitest": "^1.6.1"
   },
   "dependencies": {
-    "@intechstudio/grid-protocol": "1.20250630.1305",
+    "@intechstudio/grid-protocol": "1.20250804.1407",
     "@intechstudio/grid-uikit": "1.20250728.1324",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",

--- a/src/renderer/main/grid-layout/grid-modules/devices/VSNX.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/VSNX.svelte
@@ -148,7 +148,7 @@
   <div
     class="grid grid-cols-4 grid-rows-4 h-full w-full justify-items-center items-center"
   >
-    {#each elementArray as elementDescriptor}
+    {#each elementArray as elementDescriptor, index}
       {#if elementDescriptor.type === ElementType.LCD}
         {@const elementNumberList = [
           elementDescriptor.index - 4,
@@ -217,9 +217,7 @@
               "
               >
                 <Led
-                  color={ledcolor_array[
-                    (elementNumber == 8 ? 8 : 9) + ledNumber * 2
-                  ]}
+                  color={ledcolor_array[index == 0 ? ledNumber : 5 + ledNumber]}
                   size={1.4}
                 />
               </div>
@@ -257,13 +255,13 @@
                 {elementNumber}
                 size={4.2}
                 value={elementposition_array[elementNumber][1]}
-                color={ledcolor_array[elementNumber]}
+                color={ledcolor_array[10 + elementNumber]}
               />
             {:else}
               <Button
                 {elementNumber}
                 size={2.1}
-                color={ledcolor_array[elementNumber]}
+                color={ledcolor_array[10 + elementNumber]}
               />
             {/if}
           </div>


### PR DESCRIPTION
In firmware logical LED addresses have been changed to use hardware LED address. 
Effected modules are TEK2, VSN1, VSN2.

This PR implementes the new addressing for the effected modules.

Test procedure:
1. Download this Editor build
2. Connect a TEK2, VSN1-L, VSN1-R modules.
3. Clear configuration
4. Interact with any of the control elements -> not that in Editor incorrecd led preview is displayed on the UI.
5. Upload the correct firmware from the following branch to all modules: https://github.com/intechstudio/grid-fw/pull/240
6. See that now correct LEDs respont on the Editor UI