### PR TITLE
Fix profile load race condition for profile cloud

### DIFF
--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -37,6 +37,10 @@
   $: fetchPage($page, $selectedConfigStore);
 
   function updateState(page: GridPage, selected: any) {
+    if ($selectedConfigStore?.configType !== "profile") {
+      return;
+    }
+
     if (state === ProfileLoad.State.BUSY) {
       return;
     }


### PR DESCRIPTION
Clicking between presets and profiles should not freeze UI.

![pc_freeze](https://github.com/user-attachments/assets/78c07226-ea21-4371-b41f-8ad45e06ce54)
