### PR TITLE
SUKU fix constant polling of element name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@intechstudio/grid-protocol": "1.20250902.744",
+        "@intechstudio/grid-protocol": "1.20251001.1309",
         "@intechstudio/grid-uikit": "1.20250928.1728",
         "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
         "adm-zip": "^0.5.10",
@@ -2315,9 +2315,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@intechstudio/grid-protocol": {
-      "version": "1.20250902.744",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20250902.744.tgz",
-      "integrity": "sha512-+q7LCIm7s5qWBQfzrGFXdpY/j0ohNdbfQ9MobbAMSsWX974CflnzXC1xGLQcZmPFjsYuokCA6IFMJTXJhpVUUA=="
+      "version": "1.20251001.1309",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20251001.1309.tgz",
+      "integrity": "sha512-ljVGFaJXaI/B7HMFUNpId5mUfVCZgl58Mjc3hMNCZgyr1masExpR7vhClw2fX8pBkviIG2bjJZ0pCpnSuwSt7w=="
     },
     "node_modules/@intechstudio/grid-uikit": {
       "version": "1.20250928.1728",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vitest": "^1.6.1"
   },
   "dependencies": {
-    "@intechstudio/grid-protocol": "1.20250902.744",
+    "@intechstudio/grid-protocol": "1.20251001.1309",
     "@intechstudio/grid-uikit": "1.20250928.1728",
     "@intechstudio/profile-cloud-webcomponent": "1.20250318.1527",
     "adm-zip": "^0.5.10",

--- a/src/renderer/runtime/runtime.ts
+++ b/src/renderer/runtime/runtime.ts
@@ -1118,7 +1118,7 @@ export class GridElement extends RuntimeNode<ElementData> {
     const module = page.parent as GridModule;
 
     this.name = undefined;
-    module.execLUAImmediate(`ele[${this.elementIndex}]:gen("")`);
+    module.execLUAImmediate(`ele[${this.elementIndex}]:gen()`);
   }
 
   public isPresetLoaded(preset: GridPresetData) {

--- a/src/renderer/serialport/message-stream.store.ts
+++ b/src/renderer/serialport/message-stream.store.ts
@@ -91,8 +91,6 @@ export class MessageStream {
 
     let name = descr.class_parameters.NAME;
 
-    console.log(name, descr.raw);
-
     const element = this.runtime
       .findModule(SX, SY)
       .findPage(PAGE)

--- a/src/renderer/serialport/message-stream.store.ts
+++ b/src/renderer/serialport/message-stream.store.ts
@@ -89,21 +89,16 @@ export class MessageStream {
     const { SX, SY } = descr.brc_parameters;
     const { ELEMENT, PAGE } = descr.class_parameters;
 
+    let name = descr.class_parameters.NAME;
+
+    console.log(name, descr.raw);
+
     const element = this.runtime
       .findModule(SX, SY)
       .findPage(PAGE)
       .findElement(ELEMENT);
 
-    const setup = element.findEvent(EventTypeToNumber(EventType.SETUP));
-    const action = setup.actionAt(0);
-
-    if (action?.short === elementNameInformation.short) {
-      const regex = elementNameInformation.valueRegex;
-      const value = action.script.match(regex)[1];
-      element.name = value;
-    } else {
-      element.resetName();
-    }
+    element.name = name;
   }
 
   private update_elementPositionStore_fromPreview(descr) {


### PR DESCRIPTION
- Editor kept requesting the element name after each interaction, this caused missed heartbeat timing, now fixed.
- Editor incorrectly reset the element name to empty string, now this is fixed too
- Editor now properly listens to EVENTVIEW messages and decodes name parameter from them