### PR TITLE
Add electron logs to renderer inspector window

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -37,8 +37,8 @@ function setupRendererLogTransport() {
                            logLevel === 'debug' ? 'debug' :
                            'log';
       
-      // Format the message with [MAIN] prefix to distinguish from renderer logs
-      const prefix = `%c[MAIN]%c ${scope}`;
+      // Format the message with [ELECTRON] prefix to distinguish from renderer logs
+      const prefix = `%c[ELECTRON]%c ${scope}`;
       const prefixStyle = 'color: #ff6b6b; font-weight: bold;';
       const scopeStyle = scope ? 'color: #a78bfa;' : '';
       

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -21,6 +21,42 @@ import chokidar from "chokidar";
 // might be environment variables as well.
 import configuration from "../../configuration.json";
 
+// Add custom transport to forward logs to renderer DevTools console
+function setupRendererLogTransport() {
+  // @ts-ignore - custom transport
+  log.transports.renderer = (message) => {
+    // Only send if mainWindow exists and is not destroyed
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      const logLevel = message.level;
+      const logData = message.data;
+      const scope = message.scope ? `[${message.scope}]` : "";
+      
+      // Map electron-log levels to console methods
+      const consoleMethod = logLevel === 'error' ? 'error' :
+                           logLevel === 'warn' ? 'warn' :
+                           logLevel === 'debug' ? 'debug' :
+                           'log';
+      
+      // Format the message with [MAIN] prefix to distinguish from renderer logs
+      const prefix = `%c[MAIN]%c ${scope}`;
+      const prefixStyle = 'color: #ff6b6b; font-weight: bold;';
+      const scopeStyle = scope ? 'color: #a78bfa;' : '';
+      
+      // Execute console log in the renderer's DevTools
+      const args = logData.map(arg => 
+        typeof arg === 'object' ? JSON.stringify(arg) : String(arg)
+      ).join(' ');
+      
+      // Inject the log into renderer's console
+      mainWindow.webContents.executeJavaScript(
+        `console.${consoleMethod}("${prefix}", "${prefixStyle}", "${scopeStyle}", ${JSON.stringify(args)})`
+      ).catch(() => {
+        // Silently fail if window is closing
+      });
+    }
+  };
+}
+
 configuration.EDITOR_VERSION = app.getVersion();
 configuration.EDITOR_NAME = app.getName();
 
@@ -324,6 +360,9 @@ function createWindow() {
   firmware.mainWindow = mainWindow;
   updater.mainWindow = mainWindow;
   updater.init(store.get("nightlyEditor"));
+
+  // Setup custom log transport to forward logs to renderer
+  setupRendererLogTransport();
 
   ipcMain.on("restartAfterUpdate", () => {
     log.info('Calling "restartAfterUpdate" from main.ts');


### PR DESCRIPTION
Show all terminal messages in renderer inspector window, making it easier to debug package messages in release version of Editor