### PR TITLE
Suku calibration

### DIFF
--- a/src/renderer/main/_actions/tooltip.ts
+++ b/src/renderer/main/_actions/tooltip.ts
@@ -1,5 +1,5 @@
 import { MoltenTooltip } from "@intechstudio/grid-uikit";
-import { tooltip_content } from "../user-interface/tooltip/tooltip-content.json";
+import { tooltip_content } from "../user-interface/tooltip/tooltip-content.json.js";
 import type { Action } from "svelte/action";
 
 export const tooltip: Action<HTMLElement, any> = (

--- a/src/renderer/main/grid-layout/GridLayout.svelte
+++ b/src/renderer/main/grid-layout/GridLayout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts" context="module">
-  export const DEVICE_GAP = 5;
+  export const DEVICE_GAP = 0;
   export const DEVICE_WIDTH = 225;
   export const LAYOUT_CELL_WIDTH = DEVICE_WIDTH + DEVICE_GAP + 1;
+  export const GRID_GAP = 4; // 0.25rem gap between modules (4px)
 </script>
 
 <script lang="ts">
@@ -63,8 +64,11 @@
     const dim = getGridDimensions();
     rows = dim.rows;
     columns = dim.columns;
-    width = columns * LAYOUT_CELL_WIDTH * scale;
-    height = rows * LAYOUT_CELL_WIDTH * scale;
+    // Account for gaps between modules (N modules = N-1 gaps)
+    const gapWidth = Math.max(0, columns - 1) * GRID_GAP * scale;
+    const gapHeight = Math.max(0, rows - 1) * GRID_GAP * scale;
+    width = columns * LAYOUT_CELL_WIDTH * scale + gapWidth;
+    height = rows * LAYOUT_CELL_WIDTH * scale + gapHeight;
     layoutWidth = rotation == 0 || rotation == 180 ? width : height;
     layoutHeight = rotation == 90 || rotation == 270 ? width : height;
     shiftX = rotation == 90 || rotation == 180 ? layoutWidth : 0;
@@ -190,8 +194,9 @@
       >
         <div
           class="grid"
-          style="grid-template-columns: repeat({columns}, auto); 
+          style="grid-template-columns: repeat({columns}, auto);
           grid-template-rows: repeat({rows}, auto);
+            gap: {GRID_GAP * $scale}px;
             width: {width}px;  height: {height}px;"
         >
           {#each $runtime.modules as device (device.id)}

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -192,7 +192,7 @@
 </script>
 
 <button
-  class="module drop-shadow"
+  class="module"
   class:activator-button={interactive}
   style="transform-origin: top left; transform: scale({scale})"
   tabindex={interactive ? 0 : -1}
@@ -435,8 +435,10 @@
 
     <!-- Module Overlays -->
     <svelte:fragment slot="module-overlay">
-      <ModuleInfo {device} visible={true} />
       {#if interactive}
+        {#if typeof $moduleOverlay === "undefined"}
+          <ModuleInfo {device} visible={true} />
+        {/if}
         <ProfileLoadOverlay
           {device}
           visible={$moduleOverlay === ModuleOverlay.Types.PROFILE_LOAD}
@@ -507,7 +509,6 @@
   }
 
   .module.activator-button {
-    /*border: 1px solid red;*/
   }
 
   .module.activator-button:focus-within {
@@ -528,6 +529,7 @@
   :root {
     --element-margin: 5px;
     --grid-rounding: 5px;
+    --overlay-bg: color-mix(in srgb, var(--background) 80%, transparent);
   }
   .module-dimensions {
     width: var(--module-size);
@@ -536,11 +538,11 @@
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
-    border-radius: 6px;
+    border-radius: 4px;
   }
 
   .bg-overlay {
-    background-color: rgba(30, 30, 30, 0.5);
+    background-color: var(--overlay-bg);
   }
 
   .normal-cell-underlay-container {

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -21,6 +21,7 @@
 
   //Overlays
   import ControlNameOverlay from "./overlays/ControlNameOverlay.svelte";
+  import CalibrationOverlay from "./overlays/CalibrationOverlay.svelte";
   import PresetLoadOverlay from "./overlays/PresetLoadOverlay.svelte";
 
   //Underlays
@@ -439,6 +440,10 @@
         <ProfileLoadOverlay
           {device}
           visible={$moduleOverlay === ModuleOverlay.Types.PROFILE_LOAD}
+        />
+        <CalibrationOverlay
+          {device}
+          visible={$moduleOverlay === ModuleOverlay.Types.CALIBRATION}
         />
         {#if $moduleOverlay === ModuleOverlay.Types.PROFILE_DRAG && $profileCloudConfigDrag.type === device.type}
           <div class="absolute p-2 w-full h-full flex">

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -27,10 +27,20 @@
 {#if visible}
   <container>
     <div
-      class="text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto bg-overlay"
+      class="calibration-overlay-bg text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto"
       style="transform: rotate({counterRotation}deg); border-radius: var(--grid-rounding);"
     >
-      <CalibrationButtons module={device} onCalibrate={handleCalibrate} />
+      <CalibrationButtons
+        module={device}
+        onCalibrate={handleCalibrate}
+        compact={false}
+      />
     </div>
   </container>
 {/if}
+
+<style>
+  .calibration-overlay-bg {
+    background-color: color-mix(in srgb, var(--background) 90%, transparent);
+  }
+</style>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -2,7 +2,9 @@
   import { GridModule, GridRuntime } from "./../../../../runtime/runtime";
   import { appSettings } from "../../../../runtime/app-helper.store";
   import { Grid } from "../../../../lib/_utils";
+  import { moduleOverlay } from "../../../../runtime/moduleOverlay";
   import CalibrationButtons from "../../../panels/DebugMonitor/CalibrationButtons.svelte";
+  import { MoltenPushButton } from "@intechstudio/grid-uikit";
 
   export let visible = false;
   export let device: GridModule;
@@ -22,18 +24,27 @@
   function handleCalibrate(code: string) {
     device?.execLUAImmediate(code);
   }
+
+  function handleClose() {
+    moduleOverlay.close();
+  }
 </script>
 
 {#if visible}
   <container>
     <div
-      class="calibration-overlay-bg text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto"
+      class="calibration-overlay-bg text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto gap-4"
       style="transform: rotate({counterRotation}deg); border-radius: var(--grid-rounding);"
     >
       <CalibrationButtons
         module={device}
         onCalibrate={handleCalibrate}
         compact={false}
+      />
+      <MoltenPushButton
+        text="Close Overlay"
+        style="outlined"
+        click={handleClose}
       />
     </div>
   </container>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { GridModule } from "./../../../../runtime/runtime";
+  import { appSettings } from "../../../../runtime/app-helper.store";
+  import { Grid } from "../../../../lib/_utils";
+
+  export let visible = false;
+  export let device: GridModule;
+</script>
+
+{#if visible}
+  <container>
+    <div
+      class="text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto bg-overlay"
+      style="transform: rotate({-$appSettings.persistent.moduleRotation +
+        Grid.Rotation.R90 * device?.rot}deg); border-radius: var(--grid-rounding);"
+    >
+      <p class="text-white text-center">calibration</p>
+    </div>
+  </container>
+{/if}

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -52,6 +52,6 @@
 
 <style>
   .calibration-overlay-bg {
-    background-color: color-mix(in srgb, var(--background) 90%, transparent);
+    background-color: var(--overlay-bg);
   }
 </style>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -1,18 +1,29 @@
 <script lang="ts">
-  import { GridModule } from "./../../../../runtime/runtime";
+  import { GridModule, GridRuntime } from "./../../../../runtime/runtime";
   import { appSettings } from "../../../../runtime/app-helper.store";
   import { Grid } from "../../../../lib/_utils";
 
   export let visible = false;
   export let device: GridModule;
+
+  $: runtime = device?.parent as GridRuntime;
+
+  // Match the device component's rotation: device?.rot * -90
+  // Then counter-rotate with TOTAL rotation (moduleRotation + runtime.rotation)
+  $: deviceRotValue = device?.rot ?? 0;
+  $: deviceRotationDeg = deviceRotValue * -90;
+  $: totalRotation = Grid.addRotations(
+    $appSettings.persistent.moduleRotation,
+    $runtime?.rotation ?? 0
+  );
+  $: counterRotation = -deviceRotationDeg - totalRotation;
 </script>
 
 {#if visible}
   <container>
     <div
       class="text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto bg-overlay"
-      style="transform: rotate({-$appSettings.persistent.moduleRotation +
-        Grid.Rotation.R90 * device?.rot}deg); border-radius: var(--grid-rounding);"
+      style="transform: rotate({counterRotation}deg); border-radius: var(--grid-rounding);"
     >
       <p class="text-white text-center">calibration</p>
     </div>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/CalibrationOverlay.svelte
@@ -2,6 +2,7 @@
   import { GridModule, GridRuntime } from "./../../../../runtime/runtime";
   import { appSettings } from "../../../../runtime/app-helper.store";
   import { Grid } from "../../../../lib/_utils";
+  import CalibrationButtons from "../../../panels/DebugMonitor/CalibrationButtons.svelte";
 
   export let visible = false;
   export let device: GridModule;
@@ -14,9 +15,13 @@
   $: deviceRotationDeg = deviceRotValue * -90;
   $: totalRotation = Grid.addRotations(
     $appSettings.persistent.moduleRotation,
-    $runtime?.rotation ?? 0
+    $runtime?.rotation ?? 0,
   );
   $: counterRotation = -deviceRotationDeg - totalRotation;
+
+  function handleCalibrate(code: string) {
+    device?.execLUAImmediate(code);
+  }
 </script>
 
 {#if visible}
@@ -25,7 +30,7 @@
       class="text-white w-full flex flex-col items-center justify-center rounded h-full absolute pointer-events-auto bg-overlay"
       style="transform: rotate({counterRotation}deg); border-radius: var(--grid-rounding);"
     >
-      <p class="text-white text-center">calibration</p>
+      <CalibrationButtons module={device} onCalibrate={handleCalibrate} />
     </div>
   </container>
 {/if}

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
@@ -23,10 +23,12 @@
 
 {#if visible && $element.elementIndex !== 255}
   <container class="pointer-events-auto">
-    <div class="flex w-full h-full items-center text-center p-1 bg-overlay">
+    <div
+      class="control-name-overlay-bg flex w-full h-full items-center text-center p-1"
+    >
       <p
-        class="max-w-md mx-auto break-words whitespace-normal truncate text-white"
-        style="transform: rotate({-totalRotation +
+        class="max-w-md mx-auto break-words whitespace-normal truncate"
+        style="color: var(--foreground); transform: rotate({-totalRotation +
           $module?.rot * Grid.Rotation.R90}deg);"
       >
         {typeof $element.name === "undefined" ? "" : $element.name}
@@ -34,3 +36,9 @@
     </div>
   </container>
 {/if}
+
+<style>
+  .control-name-overlay-bg {
+    background-color: var(--overlay-bg);
+  }
+</style>

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
@@ -17,7 +17,7 @@
 
   $: totalRotation = Grid.addRotations(
     $appSettings.persistent.moduleRotation,
-    $runtime?.rotation ?? 0
+    $runtime?.rotation ?? 0,
   );
 </script>
 

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ControlNameOverlay.svelte
@@ -3,6 +3,7 @@
     GridModule,
     GridElement,
     GridPage,
+    GridRuntime,
   } from "./../../../../runtime/runtime";
   import { appSettings } from "../../../../runtime/app-helper.store";
   import { Grid } from "../../../../lib/_utils";
@@ -12,6 +13,12 @@
 
   let page = element.parent as GridPage;
   let module = page.parent as GridModule;
+  $: runtime = module?.parent as GridRuntime;
+
+  $: totalRotation = Grid.addRotations(
+    $appSettings.persistent.moduleRotation,
+    $runtime?.rotation ?? 0
+  );
 </script>
 
 {#if visible && $element.elementIndex !== 255}
@@ -19,7 +26,7 @@
     <div class="flex w-full h-full items-center text-center p-1 bg-overlay">
       <p
         class="max-w-md mx-auto break-words whitespace-normal truncate text-white"
-        style="transform: rotate({-$appSettings.persistent.moduleRotation +
+        style="transform: rotate({-totalRotation +
           $module?.rot * Grid.Rotation.R90}deg);"
       >
         {typeof $element.name === "undefined" ? "" : $element.name}

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -177,7 +177,6 @@
 
   .icon-corner-cut-l:before {
     position: absolute;
-    z-index: -1;
     bottom: -35px;
     left: -35px;
     width: 46px;
@@ -186,7 +185,6 @@
   }
   .icon-corner-cut-r:before {
     position: absolute;
-    z-index: -1;
     bottom: -35px;
     right: -35px;
     width: 46px;
@@ -196,7 +194,6 @@
 
   .corner-cut-l:before {
     position: absolute;
-    z-index: -1;
     bottom: -35px;
     left: -35px;
     width: 60px;
@@ -205,7 +202,6 @@
   }
   .corner-cut-r:before {
     position: absolute;
-    z-index: -1;
     bottom: -35px;
     right: -35px;
     width: 60px;

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -24,7 +24,7 @@
 
   $: totalRotation = Grid.addRotations(
     $appSettings.persistent.moduleRotation,
-    $runtime?.rotation ?? 0
+    $runtime?.rotation ?? 0,
   );
 
   let loaded = false;

--- a/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/PresetLoadOverlay.svelte
@@ -4,6 +4,7 @@
     GridModule,
     GridPage,
     GridPresetData,
+    GridRuntime,
   } from "./../../../../runtime/runtime";
   import { selectedConfigStore } from "../../../panels/profileCloud/ProfileCloud";
   import { appSettings } from "../../../../runtime/app-helper.store";
@@ -19,6 +20,12 @@
 
   let page = element.parent as GridPage;
   let module = page.parent as GridModule;
+  $: runtime = module?.parent as GridRuntime;
+
+  $: totalRotation = Grid.addRotations(
+    $appSettings.persistent.moduleRotation,
+    $runtime?.rotation ?? 0
+  );
 
   let loaded = false;
 
@@ -81,7 +88,7 @@
       >
         <div
           class="flex w-full h-full items-center justify-center"
-          style="transform: rotate({-$appSettings.persistent.moduleRotation +
+          style="transform: rotate({-totalRotation +
             $module?.rot * Grid.Rotation.R90}deg);"
         >
           {#if !loaded}

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -54,7 +54,7 @@
   $: deviceRotationDeg = deviceRotValue * -90;
   $: totalRotation = Grid.addRotations(
     $appSettings.persistent.moduleRotation,
-    $runtime?.rotation ?? 0
+    $runtime?.rotation ?? 0,
   );
   $: counterRotation = -deviceRotationDeg - totalRotation;
 

--- a/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/overlays/ProfileLoadOverlay.svelte
@@ -25,6 +25,7 @@
     GridModule,
     GridPage,
     GridProfileData,
+    GridRuntime,
     ProfileCloudLoad,
   } from "../../../../runtime/runtime.js";
   import { loadProfile } from "../../../../runtime/operations";
@@ -44,6 +45,18 @@
 
   export let device: GridModule;
   export let visible = false;
+
+  $: runtime = device?.parent as GridRuntime;
+
+  // Match the device component's rotation: device?.rot * -90
+  // Then counter-rotate with TOTAL rotation (moduleRotation + runtime.rotation)
+  $: deviceRotValue = device?.rot ?? 0;
+  $: deviceRotationDeg = deviceRotValue * -90;
+  $: totalRotation = Grid.addRotations(
+    $appSettings.persistent.moduleRotation,
+    $runtime?.rotation ?? 0
+  );
+  $: counterRotation = -deviceRotationDeg - totalRotation;
 
   let page = derived([device, user_input], ([$device, $user_input]) =>
     device.findPage($user_input.pagenumber),
@@ -172,9 +185,7 @@
     <div
       class="text-white w-full flex flex-col
   items-center justify-center rounded h-full absolute pointer-events-auto bg-overlay"
-      style="transform: rotate({-$appSettings.persistent.moduleRotation +
-        Grid.Rotation.R90 *
-          device?.rot}deg); border-radius: var(--grid-rounding);"
+      style="transform: rotate({counterRotation}deg); border-radius: var(--grid-rounding);"
     >
       {#if typeof $selectedConfigStore !== "undefined" && isCompatible(device.type, $selectedConfigStore.type)}
         {#if $page.isLoaded()}

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
@@ -5,6 +5,7 @@
   export let text: string;
   export let code: string;
   export let onClick: (code: string) => void;
+  export let disabled: boolean = false;
 
   function handleClick() {
     onClick(code);
@@ -17,5 +18,5 @@
     placement: "top",
   }}
 >
-  <MoltenPushButton click={handleClick} {text} />
+  <MoltenPushButton click={handleClick} {text} {disabled} />
 </div>

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
@@ -5,19 +5,40 @@
   export let style: string | undefined;
   export let text: string;
   export let code: string;
+  export let tooltipKey: string | undefined = undefined;
   export let onClick: (code: string) => void;
   export let disabled: boolean = false;
+  export let confirm: boolean = false;
 
   function handleClick() {
     onClick(code);
   }
+
+  $: baseConfig = tooltipKey
+    ? { key: tooltipKey, placement: "top" as const }
+    : { text: code, placement: "top" as const };
+
+  $: tooltipConfig = confirm
+    ? {
+        ...baseConfig,
+        class: "w-60 p-4",
+        buttons: [
+          {
+            label: "Cancel",
+            handler: undefined,
+          },
+          { label: "Confirm", handler: handleClick },
+        ],
+        triggerEvents: ["show-buttons", "hover"],
+      }
+    : baseConfig;
 </script>
 
-<div
-  use:tooltip={{
-    text: code,
-    placement: "top",
-  }}
->
-  <MoltenPushButton {style} click={handleClick} {text} {disabled} />
+<div use:tooltip={tooltipConfig}>
+  <MoltenPushButton
+    {style}
+    click={confirm ? () => {} : handleClick}
+    {text}
+    {disabled}
+  />
 </div>

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
@@ -2,6 +2,7 @@
   import { MoltenPushButton } from "@intechstudio/grid-uikit";
   import { tooltip } from "../../_actions/tooltip";
 
+  export let style: string | undefined;
   export let text: string;
   export let code: string;
   export let onClick: (code: string) => void;
@@ -18,5 +19,5 @@
     placement: "top",
   }}
 >
-  <MoltenPushButton click={handleClick} {text} {disabled} />
+  <MoltenPushButton {style} click={handleClick} {text} {disabled} />
 </div>

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButton.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { MoltenPushButton } from "@intechstudio/grid-uikit";
+  import { tooltip } from "../../_actions/tooltip";
+
+  export let text: string;
+  export let code: string;
+  export let onClick: (code: string) => void;
+
+  function handleClick() {
+    onClick(code);
+  }
+</script>
+
+<div
+  use:tooltip={{
+    text: code,
+    placement: "top",
+  }}
+>
+  <MoltenPushButton click={handleClick} {text} />
+</div>

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -5,68 +5,86 @@
 
   export let module: GridModule | undefined = undefined;
   export let onCalibrate: (code: string) => void;
+  export let compact: boolean = true;
 
   // Check what calibrations the selected module supports
   // - Potmeters: Center, Range, Detent Low, Detent High
   // - Buttons: Range only (RevH revision only)
   // - Other elements: no calibration
-  $: hasCenterCalibration = module ? checkCenterCalibration(module) : false;
-  $: hasRangeCalibration = module ? checkRangeCalibration(module) : false;
-  $: hasDetentCalibration = module ? checkDetentCalibration(module) : false;
 
-  function checkCenterCalibration(module: GridModule): boolean {
-    const elementList = grid.get_module_element_list(module.type);
-    return elementList.some((element) => element === "potmeter");
-  }
+  // Cache element list to avoid multiple lookups
+  $: elementList = module ? grid.get_module_element_list(module.type) : [];
+  $: hasPotmeter = elementList.some((element) => element === "potmeter");
+  $: hasButton = elementList.some((element) => element === "button");
+  $: isRevH = module?.revision === "RevH";
 
-  function checkRangeCalibration(module: GridModule): boolean {
-    const elementList = grid.get_module_element_list(module.type);
-    const hasPotmeter = elementList.some((element) => element === "potmeter");
-    const hasButton = elementList.some((element) => element === "button");
-    const isRevH = module.revision === "RevH";
-    return hasPotmeter || (hasButton && isRevH);
-  }
+  // Center and Detent calibrations are only for potmeters
+  $: hasCenterCalibration = hasPotmeter;
+  $: hasDetentCalibration = hasPotmeter;
 
-  function checkDetentCalibration(module: GridModule): boolean {
-    const elementList = grid.get_module_element_list(module.type);
-    return elementList.some((element) => element === "potmeter");
-  }
+  // Range calibration is for potmeters or RevH buttons
+  $: hasRangeCalibration = hasPotmeter || (hasButton && isRevH);
+
+  // Button configurations
+  $: buttons = [
+    {
+      text: "Center",
+      code: "local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))",
+      tooltipKey: "calibration_center",
+      enabled: hasCenterCalibration,
+    },
+    {
+      text: "Range",
+      code: "local caldata = grcg() grcs(caldata) print(table.unpack(caldata))",
+      tooltipKey: "calibration_range",
+      enabled: hasRangeCalibration,
+    },
+    {
+      text: "Detent Low",
+      code: "local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))",
+      tooltipKey: "calibration_detent_low",
+      enabled: hasDetentCalibration,
+    },
+    {
+      text: "Detent High",
+      code: "local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))",
+      tooltipKey: "calibration_detent_high",
+      enabled: hasDetentCalibration,
+    },
+    {
+      text: "Reset",
+      code: "gcr()",
+      tooltipKey: "calibration_reset",
+      enabled:
+        hasCenterCalibration || hasRangeCalibration || hasDetentCalibration,
+      style: "outlined",
+      confirm: true,
+    },
+  ];
+
+  $: hasAnyCalibration = buttons.some((btn) => btn.enabled);
 </script>
 
-<div class="flex flex-row flex-wrap gap-1">
-  <CalibrationButton
-    text="Center"
-    code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
-    onClick={onCalibrate}
-    disabled={!hasCenterCalibration}
-  />
-  <CalibrationButton
-    text="Range"
-    code="local caldata = grcg() grcs(caldata) print(table.unpack(caldata))"
-    onClick={onCalibrate}
-    disabled={!hasRangeCalibration}
-  />
-  <CalibrationButton
-    text="Detent Low"
-    code="local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))"
-    onClick={onCalibrate}
-    disabled={!hasDetentCalibration}
-  />
-  <CalibrationButton
-    text="Detent High"
-    code="local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))"
-    onClick={onCalibrate}
-    disabled={!hasDetentCalibration}
-  />
-  <CalibrationButton
-    text="Reset"
-    code="gcr()"
-    onClick={onCalibrate}
-    style={"outlined"}
-    disabled={!(
-      hasCenterCalibration ||
-      hasRangeCalibration ||
-      hasDetentCalibration
-    )}
-  />
-</div>
+{#if !compact && !hasAnyCalibration}
+  <div class="text-white text-center py-2">
+    No calibration is available for this module type!
+  </div>
+{:else}
+  <div
+    class="flex gap-1 {compact
+      ? 'flex-row flex-wrap'
+      : 'flex-col items-center'}"
+  >
+    {#each buttons.filter((btn) => compact || btn.enabled) as button (button.text)}
+      <CalibrationButton
+        text={button.text}
+        code={button.code}
+        tooltipKey={compact ? undefined : button.tooltipKey}
+        onClick={onCalibrate}
+        style={button.style}
+        confirm={!compact && button.confirm}
+        disabled={!button.enabled}
+      />
+    {/each}
+  </div>
+{/if}

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -66,9 +66,7 @@
 </script>
 
 {#if !compact && !hasAnyCalibration}
-  <div class="text-white text-center py-2">
-    No calibration is available for this module type!
-  </div>
+  <div class="text-white text-center py-2">No calibration is available!</div>
 {:else}
   <div
     class="flex gap-1 {compact

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import CalibrationButton from "./CalibrationButton.svelte";
+  import { grid } from "@intechstudio/grid-protocol";
+  import type { GridModule } from "../../../runtime/runtime";
+
+  export let module: GridModule | undefined = undefined;
+  export let onCalibrate: (code: string) => void;
+
+  // Check what calibrations the selected module supports
+  // - Potmeters: Center, Range, Detent Low, Detent High
+  // - Buttons: Range only (RevH revision only)
+  // - Other elements: no calibration
+  $: hasCenterCalibration = module ? checkCenterCalibration(module) : false;
+  $: hasRangeCalibration = module ? checkRangeCalibration(module) : false;
+  $: hasDetentCalibration = module ? checkDetentCalibration(module) : false;
+
+  function checkCenterCalibration(module: GridModule): boolean {
+    const elementList = grid.get_module_element_list(module.type);
+    return elementList.some((element) => element === "potmeter");
+  }
+
+  function checkRangeCalibration(module: GridModule): boolean {
+    const elementList = grid.get_module_element_list(module.type);
+    const hasPotmeter = elementList.some((element) => element === "potmeter");
+    const hasButton = elementList.some((element) => element === "button");
+    const isRevH = module.revision === "RevH";
+    return hasPotmeter || (hasButton && isRevH);
+  }
+
+  function checkDetentCalibration(module: GridModule): boolean {
+    const elementList = grid.get_module_element_list(module.type);
+    return elementList.some((element) => element === "potmeter");
+  }
+</script>
+
+<div class="flex flex-row flex-wrap gap-1">
+  <CalibrationButton
+    text="Center"
+    code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
+    onClick={onCalibrate}
+    disabled={!hasCenterCalibration}
+  />
+  <CalibrationButton
+    text="Range"
+    code="local caldata = grcg() grcs(caldata) print(table.unpack(caldata))"
+    onClick={onCalibrate}
+    disabled={!hasRangeCalibration}
+  />
+  <CalibrationButton
+    text="Detent Low"
+    code="local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))"
+    onClick={onCalibrate}
+    disabled={!hasDetentCalibration}
+  />
+  <CalibrationButton
+    text="Detent High"
+    code="local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))"
+    onClick={onCalibrate}
+    disabled={!hasDetentCalibration}
+  />
+  <CalibrationButton
+    text="Reset"
+    code="gcr()"
+    onClick={onCalibrate}
+    style={"outlined"}
+    disabled={!(
+      hasCenterCalibration ||
+      hasRangeCalibration ||
+      hasDetentCalibration
+    )}
+  />
+</div>

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -52,12 +52,11 @@
       enabled: hasDetentCalibration,
     },
     {
-      text: "Reset",
+      text: "Delete Calibration",
       code: "gcr()",
       tooltipKey: "calibration_reset",
       enabled:
         hasCenterCalibration || hasRangeCalibration || hasDetentCalibration,
-      style: "outlined",
       confirm: true,
     },
   ];

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -29,25 +29,25 @@
   $: buttons = [
     {
       text: "Center",
-      code: "local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))",
+      code: "local caldata = gpcg() gpcs(caldata) print('INFO: Calibration Center', table.unpack(caldata))",
       tooltipKey: "calibration_center",
       enabled: hasCenterCalibration,
     },
     {
       text: "Range",
-      code: "local caldata = grcg() grcs(caldata) print(table.unpack(caldata))",
+      code: "local caldata = grcg() grcs(caldata) print('INFO: Calibration Range', table.unpack(caldata))",
       tooltipKey: "calibration_range",
       enabled: hasRangeCalibration,
     },
     {
       text: "Detent Low",
-      code: "local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))",
+      code: "local caldata = gpcg() gpds(caldata, false) print('INFO: Calibration Detent Low', table.unpack(caldata))",
       tooltipKey: "calibration_detent_low",
       enabled: hasDetentCalibration,
     },
     {
       text: "Detent High",
-      code: "local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))",
+      code: "local caldata = gpcg() gpds(caldata, true) print('INFO: Calibration Detent High', table.unpack(caldata))",
       tooltipKey: "calibration_detent_high",
       enabled: hasDetentCalibration,
     },

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -9,12 +9,14 @@
 
   // Check what calibrations the selected module supports
   // - Potmeters: Center, Range, Detent Low, Detent High
+  // - Faders: Range only
   // - Buttons: Range only (RevH revision only)
   // - Other elements: no calibration
 
   // Cache element list to avoid multiple lookups
   $: elementList = module ? grid.get_module_element_list(module.type) : [];
   $: hasPotmeter = elementList.some((element) => element === "potmeter");
+  $: hasFader = elementList.some((element) => element === "fader");
   $: hasButton = elementList.some((element) => element === "button");
   $: isRevH = module?.revision === "RevH";
 
@@ -22,8 +24,8 @@
   $: hasCenterCalibration = hasPotmeter;
   $: hasDetentCalibration = hasPotmeter;
 
-  // Range calibration is for potmeters or RevH buttons
-  $: hasRangeCalibration = hasPotmeter || (hasButton && isRevH);
+  // Range calibration is for potmeters, faders, or RevH buttons
+  $: hasRangeCalibration = hasPotmeter || hasFader || (hasButton && isRevH);
 
   // Button configurations
   $: buttons = [

--- a/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
+++ b/src/renderer/main/panels/DebugMonitor/CalibrationButtons.svelte
@@ -65,7 +65,9 @@
 </script>
 
 {#if !compact && !hasAnyCalibration}
-  <div class="text-white text-center py-2">No calibration is available!</div>
+  <div class="text-center py-2" style="color: var(--foreground-muted);">
+    No calibration is available!
+  </div>
 {:else}
   <div
     class="flex gap-1 {compact

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -20,7 +20,11 @@
   import PolyLineGraph from "../../user-interface/PolyLineGraph.svelte";
   import { incoming_messages } from "../../../serialport/message-stream.store";
   import { Pane, Splitpanes } from "svelte-splitpanes";
-  import { MoltenPushButton, MoltenInput } from "@intechstudio/grid-uikit";
+  import {
+    MoltenPushButton,
+    MoltenInput,
+    MeltRadio,
+  } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { Grid } from "../../../lib/_utils";
   import DebugTextList from "./DebugTextList.svelte";
@@ -198,33 +202,6 @@
   </div>
   <SendInmediate />
 
-  <div class="flex felx-row gap-2 flex-wrap text-white items-center my-4">
-    <MoltenPushButton click={clearDebugtext} text="Clear" />
-    <MoltenPushButton
-      click={() => {
-        display = "DEC";
-      }}
-      text="DEC"
-    />
-    <MoltenPushButton
-      click={() => {
-        display = "HEX";
-      }}
-      text="HEX"
-    />
-    <MoltenPushButton
-      click={() => {
-        display = "CHAR";
-      }}
-      text="CHAR"
-    />
-
-    {#if frozen == false}
-      <MoltenPushButton text="Freeze" click={freezeDebugtext} />
-    {:else}
-      <MoltenPushButton text="Unfreeze" click={unfreezeDebugtext} />
-    {/if}
-  </div>
   <Splitpanes
     theme="modern-theme"
     class="w-full overflow-hidden"
@@ -236,6 +213,29 @@
     <Pane class="overflow-hidden">
       {#if $debug_lowlevel_store.length != 0}
         <div class="flex flex-col w-full h-full">
+          <div class="flex flex-row gap-2 text-white items-center my-2">
+            <div class="inline-flex">
+              <MeltRadio
+                bind:target={display}
+                style="button"
+                orientation="horizontal"
+                options={[
+                  { title: "DEC", value: "DEC" },
+                  { title: "HEX", value: "HEX" },
+                  { title: "CHAR", value: "CHAR" },
+                ]}
+              />
+            </div>
+            <div class="flex-grow"></div>
+            <div class="flex gap-4">
+              {#if frozen == false}
+                <MoltenPushButton text="Freeze" click={freezeDebugtext} />
+              {:else}
+                <MoltenPushButton text="Unfreeze" click={unfreezeDebugtext} />
+              {/if}
+              <MoltenPushButton click={clearDebugtext} text="Clear" />
+            </div>
+          </div>
           <div class="text-white mt-2">Raw Packet:</div>
           <div
             class="flex flex-grow w-full selectable overflow-y-auto p-1"

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -29,7 +29,7 @@
   import { Grid } from "../../../lib/_utils";
   import DebugTextList from "./DebugTextList.svelte";
   import { scrollToBottom } from "../../_actions/scroll.move";
-  import SendInmediate from "./SendInmediate.svelte";
+  import SendImmediate from "./SendImmediate.svelte";
 
   let event: GridEvent;
 
@@ -200,7 +200,7 @@
       <MoltenPushButton text="Show Code" click={handleShowCode} />
     </div>
   </div>
-  <SendInmediate />
+  <SendImmediate />
 
   <Splitpanes
     theme="modern-theme"

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -27,7 +27,7 @@
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
-      value: 'print("hello")',
+      value: 'print("INFO: hello")',
       language: "lua",
       theme: $appSettings.persistent.lightMode
         ? MonacoEditor.Theme.LIGHT

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -16,15 +16,14 @@
   import { Runtime } from "../../../runtime/string-table";
   import type { ModuleType } from "@intechstudio/grid-protocol";
   import { grid } from "@intechstudio/grid-protocol";
-  import CalibrationButton from "./CalibrationButton.svelte";
+  import type { GridModule } from "../../../runtime/runtime";
+  import CalibrationButtons from "./CalibrationButtons.svelte";
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
   let selectedModule: string = "all";
   let moduleOptions: Array<{ title: string; value: string }> = [];
-  let hasCenterCalibration: boolean = false;
-  let hasRangeCalibration: boolean = false;
-  let hasDetentCalibration: boolean = false;
+  let currentModule: GridModule | undefined = undefined;
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
@@ -148,42 +147,19 @@
     sendLuaCode(value);
   }
 
-  // Check what calibrations the selected module supports
-  // - Potmeters: Center, Range, Detent Low, Detent High
-  // - Buttons: Range only (RevH revision only)
-  // - Other elements: no calibration
+  // Get the current module for calibration
   $: {
     if (selectedModule === "all") {
-      hasCenterCalibration = false;
-      hasRangeCalibration = false;
-      hasDetentCalibration = false;
+      currentModule = undefined;
     } else {
       const runtime = get(runtime_manager)?.active?.runtime;
       if (runtime) {
         const [dxStr, dyStr] = selectedModule.split(",");
         const dxNum = parseInt(dxStr) || 0;
         const dyNum = parseInt(dyStr) || 0;
-        const module = runtime.findModule(dxNum, dyNum);
-        if (module) {
-          const elementList = grid.get_module_element_list(module.type);
-          const hasPotmeter = elementList.some(
-            (element) => element === "potmeter",
-          );
-          const hasButton = elementList.some((element) => element === "button");
-          const isRevH = module.revision === "RevH";
-
-          hasCenterCalibration = hasPotmeter;
-          hasRangeCalibration = hasPotmeter || (hasButton && isRevH);
-          hasDetentCalibration = hasPotmeter;
-        } else {
-          hasCenterCalibration = false;
-          hasRangeCalibration = false;
-          hasDetentCalibration = false;
-        }
+        currentModule = runtime.findModule(dxNum, dyNum);
       } else {
-        hasCenterCalibration = false;
-        hasRangeCalibration = false;
-        hasDetentCalibration = false;
+        currentModule = undefined;
       }
     }
   }
@@ -208,41 +184,5 @@
     />
   </BlockRow>
   <BlockTitle>Calibration options</BlockTitle>
-  <div class="flex flex-row flex-wrap gap-1">
-    <CalibrationButton
-      text="Center"
-      code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
-      onClick={sendLuaCode}
-      disabled={!hasCenterCalibration}
-    />
-    <CalibrationButton
-      text="Range"
-      code="local caldata = grcg() grcs(caldata) print(table.unpack(caldata))"
-      onClick={sendLuaCode}
-      disabled={!hasRangeCalibration}
-    />
-    <CalibrationButton
-      text="Detent Low"
-      code="local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))"
-      onClick={sendLuaCode}
-      disabled={!hasDetentCalibration}
-    />
-    <CalibrationButton
-      text="Detent High"
-      code="local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))"
-      onClick={sendLuaCode}
-      disabled={!hasDetentCalibration}
-    />
-    <CalibrationButton
-      text="Reset"
-      code="gcr()"
-      onClick={sendLuaCode}
-      style={"outlined"}
-      disabled={!(
-        hasCenterCalibration ||
-        hasRangeCalibration ||
-        hasDetentCalibration
-      )}
-    />
-  </div>
+  <CalibrationButtons module={currentModule} onCalibrate={sendLuaCode} />
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -208,7 +208,7 @@
     />
   </BlockRow>
   <BlockTitle>Calibration options</BlockTitle>
-  <BlockRow>
+  <div class="flex flex-row flex-wrap gap-1">
     <CalibrationButton
       text="Center"
       code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
@@ -237,11 +237,12 @@
       text="Reset"
       code="gcr()"
       onClick={sendLuaCode}
+      style={"outlined"}
       disabled={!(
         hasCenterCalibration ||
         hasRangeCalibration ||
         hasDetentCalibration
       )}
     />
-  </BlockRow>
+  </div>
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { MoltenPushButton } from "@intechstudio/grid-uikit";
+  import {
+    MoltenPushButton,
+    MeltSelect,
+    Block,
+    BlockRow,
+  } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { GridInstruction } from "../../../serialport/instructions";
   import { onMount } from "svelte";
@@ -8,13 +13,16 @@
   import { get } from "svelte/store";
   import { logger } from "../../../runtime/runtime.store";
   import { Runtime } from "../../../runtime/string-table";
+  import type { ModuleType } from "@intechstudio/grid-protocol";
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
+  let selectedModule: string = "all";
+  let moduleOptions: Array<{ title: string; value: string }> = [];
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
-      value: "",
+      value: 'print("hello")',
       language: "lua",
       theme: $appSettings.persistent.lightMode
         ? MonacoEditor.Theme.LIGHT
@@ -35,6 +43,9 @@
       },
       lineNumbers: "off",
     });
+
+    // Initial module list population
+    refreshModuleList();
   });
 
   $: if (editor) {
@@ -47,10 +58,43 @@
     );
   }
 
+  function refreshModuleList() {
+    const runtime = get(runtime_manager)?.active?.runtime;
+    const modules = runtime?.modules || [];
+
+    const newOptions = [
+      { title: "All Modules (Global)", value: "all" },
+      ...modules.map((module) => ({
+        title: `Module [${module.dx}, ${module.dy}] - ${getModuleTypeName(module.type)}`,
+        value: `${module.dx},${module.dy}`,
+      })),
+    ];
+
+    // Check if selected module still exists
+    if (selectedModule !== "all") {
+      const selectedExists = newOptions.some(
+        (opt) => opt.value === selectedModule,
+      );
+      if (!selectedExists) {
+        selectedModule = "all";
+      }
+    }
+
+    moduleOptions = newOptions;
+  }
+
+  function getModuleTypeName(type: ModuleType): string {
+    if (typeof type === "object" && type.type) {
+      return type.type;
+    }
+    return String(type);
+  }
+
   function handleSendImmediateclicked() {
     const value = editor.getValue();
-    const module = get(runtime_manager).active?.runtime.findModule(0, 0);
-    if (!module) {
+    const runtime = get(runtime_manager).active?.runtime;
+
+    if (!runtime) {
       logger.set({
         type: "fail",
         classname: "pagechange",
@@ -59,14 +103,58 @@
       });
       return;
     }
-    module.execLUAImmediate(value);
+
+    if (selectedModule === "all") {
+      // Send to all modules
+      const modules = runtime.modules;
+      if (modules.length === 0) {
+        logger.set({
+          type: "fail",
+          classname: "pagechange",
+          mode: 0,
+          message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
+        });
+        return;
+      }
+      modules.forEach((module) => {
+        module.execLUAImmediate(value);
+      });
+    } else {
+      // Send to specific module
+      const [dxStr, dyStr] = selectedModule.split(",");
+      const dxNum = parseInt(dxStr) || 0;
+      const dyNum = parseInt(dyStr) || 0;
+      const module = runtime.findModule(dxNum, dyNum);
+      if (!module) {
+        logger.set({
+          type: "fail",
+          classname: "pagechange",
+          mode: 0,
+          message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
+        });
+        return;
+      }
+      module.execLUAImmediate(value);
+    }
   }
 </script>
 
-<div class="grid grid-cols-[1fr_auto] gap-2 items-center h-32">
-  <div
-    bind:this={monacoElement}
-    class="flex w-full h-full border border-black"
-  />
-  <MoltenPushButton click={handleSendImmediateclicked} text="Immediate" />
-</div>
+<Block>
+  <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
+  <BlockRow>
+    <div class="flex-grow">
+      {#key moduleOptions}
+        <MeltSelect
+          bind:target={selectedModule}
+          options={moduleOptions}
+          disabled={false}
+        />
+      {/key}
+    </div>
+    <MoltenPushButton click={refreshModuleList} text="Refresh List" />
+    <MoltenPushButton
+      click={handleSendImmediateclicked}
+      text="Send Immediate"
+    />
+  </BlockRow>
+</Block>

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -15,12 +15,16 @@
   import { logger } from "../../../runtime/runtime.store";
   import { Runtime } from "../../../runtime/string-table";
   import type { ModuleType } from "@intechstudio/grid-protocol";
+  import { grid } from "@intechstudio/grid-protocol";
   import CalibrationButton from "./CalibrationButton.svelte";
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
   let selectedModule: string = "all";
   let moduleOptions: Array<{ title: string; value: string }> = [];
+  let hasCenterCalibration: boolean = false;
+  let hasRangeCalibration: boolean = false;
+  let hasDetentCalibration: boolean = false;
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
@@ -143,6 +147,46 @@
     const value = editor.getValue();
     sendLuaCode(value);
   }
+
+  // Check what calibrations the selected module supports
+  // - Potmeters: Center, Range, Detent Low, Detent High
+  // - Buttons: Range only (RevH revision only)
+  // - Other elements: no calibration
+  $: {
+    if (selectedModule === "all") {
+      hasCenterCalibration = false;
+      hasRangeCalibration = false;
+      hasDetentCalibration = false;
+    } else {
+      const runtime = get(runtime_manager)?.active?.runtime;
+      if (runtime) {
+        const [dxStr, dyStr] = selectedModule.split(",");
+        const dxNum = parseInt(dxStr) || 0;
+        const dyNum = parseInt(dyStr) || 0;
+        const module = runtime.findModule(dxNum, dyNum);
+        if (module) {
+          const elementList = grid.get_module_element_list(module.type);
+          const hasPotmeter = elementList.some(
+            (element) => element === "potmeter",
+          );
+          const hasButton = elementList.some((element) => element === "button");
+          const isRevH = module.revision === "RevH";
+
+          hasCenterCalibration = hasPotmeter;
+          hasRangeCalibration = hasPotmeter || (hasButton && isRevH);
+          hasDetentCalibration = hasPotmeter;
+        } else {
+          hasCenterCalibration = false;
+          hasRangeCalibration = false;
+          hasDetentCalibration = false;
+        }
+      } else {
+        hasCenterCalibration = false;
+        hasRangeCalibration = false;
+        hasDetentCalibration = false;
+      }
+    }
+  }
 </script>
 
 <Block>
@@ -163,27 +207,58 @@
       text="Send Immediate"
     />
   </BlockRow>
-  <BlockTitle>Calibration</BlockTitle>
+  <BlockTitle>Generate Calibration</BlockTitle>
   <BlockRow>
     <CalibrationButton
       text="Center"
       code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
       onClick={sendLuaCode}
+      disabled={!hasCenterCalibration}
     />
     <CalibrationButton
       text="Range"
       code="local caldata = grcg() grcs(caldata) print(table.unpack(caldata))"
       onClick={sendLuaCode}
+      disabled={!hasRangeCalibration}
     />
     <CalibrationButton
       text="Detent Low"
       code="local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))"
       onClick={sendLuaCode}
+      disabled={!hasDetentCalibration}
     />
     <CalibrationButton
       text="Detent High"
       code="local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))"
       onClick={sendLuaCode}
+      disabled={!hasDetentCalibration}
+    />
+  </BlockRow>
+  <BlockTitle>Clear Calibration</BlockTitle>
+  <BlockRow>
+    <CalibrationButton
+      text="Center"
+      code="gpcs(nil)"
+      onClick={sendLuaCode}
+      disabled={!hasCenterCalibration}
+    />
+    <CalibrationButton
+      text="Range"
+      code="grcs(nil)"
+      onClick={sendLuaCode}
+      disabled={!hasRangeCalibration}
+    />
+    <CalibrationButton
+      text="Detent Low"
+      code="gpds(nil, false)"
+      onClick={sendLuaCode}
+      disabled={!hasDetentCalibration}
+    />
+    <CalibrationButton
+      text="Detent High"
+      code="gpds(nil, true)"
+      onClick={sendLuaCode}
+      disabled={!hasDetentCalibration}
     />
   </BlockRow>
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -4,6 +4,7 @@
     MeltSelect,
     Block,
     BlockRow,
+    BlockTitle,
   } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { GridInstruction } from "../../../serialport/instructions";
@@ -14,6 +15,7 @@
   import { logger } from "../../../runtime/runtime.store";
   import { Runtime } from "../../../runtime/string-table";
   import type { ModuleType } from "@intechstudio/grid-protocol";
+  import CalibrationButton from "./CalibrationButton.svelte";
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
@@ -90,8 +92,7 @@
     return String(type);
   }
 
-  function handleSendImmediateclicked() {
-    const value = editor.getValue();
+  function sendLuaCode(code: string) {
     const runtime = get(runtime_manager).active?.runtime;
 
     if (!runtime) {
@@ -117,7 +118,7 @@
         return;
       }
       modules.forEach((module) => {
-        module.execLUAImmediate(value);
+        module.execLUAImmediate(code);
       });
     } else {
       // Send to specific module
@@ -134,8 +135,13 @@
         });
         return;
       }
-      module.execLUAImmediate(value);
+      module.execLUAImmediate(code);
     }
+  }
+
+  function handleSendImmediateclicked() {
+    const value = editor.getValue();
+    sendLuaCode(value);
   }
 </script>
 
@@ -155,6 +161,29 @@
     <MoltenPushButton
       click={handleSendImmediateclicked}
       text="Send Immediate"
+    />
+  </BlockRow>
+  <BlockTitle>Calibration</BlockTitle>
+  <BlockRow>
+    <CalibrationButton
+      text="Center"
+      code="local caldata = gpcg() gpcs(caldata) print(table.unpack(caldata))"
+      onClick={sendLuaCode}
+    />
+    <CalibrationButton
+      text="Range"
+      code="local caldata = grcg() grcs(caldata) print(table.unpack(caldata))"
+      onClick={sendLuaCode}
+    />
+    <CalibrationButton
+      text="Detent Low"
+      code="local caldata = gpcg() gpds(caldata, false) print(table.unpack(caldata))"
+      onClick={sendLuaCode}
+    />
+    <CalibrationButton
+      text="Detent High"
+      code="local caldata = gpcg() gpds(caldata, true) print(table.unpack(caldata))"
+      onClick={sendLuaCode}
     />
   </BlockRow>
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendInmediate.svelte
@@ -207,7 +207,7 @@
       text="Send Immediate"
     />
   </BlockRow>
-  <BlockTitle>Generate Calibration</BlockTitle>
+  <BlockTitle>Calibration options</BlockTitle>
   <BlockRow>
     <CalibrationButton
       text="Center"
@@ -233,32 +233,15 @@
       onClick={sendLuaCode}
       disabled={!hasDetentCalibration}
     />
-  </BlockRow>
-  <BlockTitle>Clear Calibration</BlockTitle>
-  <BlockRow>
     <CalibrationButton
-      text="Center"
-      code="gpcs(nil)"
+      text="Reset"
+      code="gcr()"
       onClick={sendLuaCode}
-      disabled={!hasCenterCalibration}
-    />
-    <CalibrationButton
-      text="Range"
-      code="grcs(nil)"
-      onClick={sendLuaCode}
-      disabled={!hasRangeCalibration}
-    />
-    <CalibrationButton
-      text="Detent Low"
-      code="gpds(nil, false)"
-      onClick={sendLuaCode}
-      disabled={!hasDetentCalibration}
-    />
-    <CalibrationButton
-      text="Detent High"
-      code="gpds(nil, true)"
-      onClick={sendLuaCode}
-      disabled={!hasDetentCalibration}
+      disabled={!(
+        hasCenterCalibration ||
+        hasRangeCalibration ||
+        hasDetentCalibration
+      )}
     />
   </BlockRow>
 </Block>

--- a/src/renderer/main/panels/preferences/Preferences.svelte
+++ b/src/renderer/main/panels/preferences/Preferences.svelte
@@ -90,6 +90,12 @@
   </Block>
   {#if activePreferenceMenu == PreferenceMenu.GENERAL}
     <Block>
+      <BlockTitle>Light Color Theme</BlockTitle>
+      <MeltCheckbox
+        bind:target={$appSettings.persistent.lightMode}
+        title={"Light Mode Enabled"}
+      />
+
       <BlockTitle>Control surface rotation</BlockTitle>
       <BlockBody>
         Changes how the controllers are rotated in Grid Editor. Useful when the
@@ -288,14 +294,6 @@
 
   {#if activePreferenceMenu == PreferenceMenu.DEVELOPER}
     <Block>
-      <BlockTitle>Enable light mode</BlockTitle>
-      <BlockBody
-        >An experimental mode to set the color scheme to light mode.</BlockBody
-      >
-      <MeltCheckbox
-        bind:target={$appSettings.persistent.lightMode}
-        title={"Enabled"}
-      />
       <BlockTitle>Enable events loaded</BlockTitle>
       <BlockBody
         >Display on modules the number of events that are loaded and synced with

--- a/src/renderer/main/user-interface/Tracker.svelte
+++ b/src/renderer/main/user-interface/Tracker.svelte
@@ -55,6 +55,15 @@
       moduleOverlay.close();
     }
   }
+
+  function showCalibrationOverlay() {
+    const show = get(moduleOverlay) !== ModuleOverlay.Types.CALIBRATION;
+    if (show) {
+      moduleOverlay.show(ModuleOverlay.Types.CALIBRATION);
+    } else {
+      moduleOverlay.close();
+    }
+  }
 </script>
 
 <container class={$$props.class}>
@@ -73,6 +82,19 @@
         title="Name Overlay"
         on:change={showControlElementNameOverlay}
         value={$moduleOverlay === ModuleOverlay.Types.CONTROL_NAME}
+      />
+    </div>
+    <div
+      use:tooltip={{
+        placement: "top",
+        class: "w-60 p-4 z-10",
+        key: "configuration_calibration",
+      }}
+    >
+      <Toggle
+        title="Calibration Overlay"
+        on:change={showCalibrationOverlay}
+        value={$moduleOverlay === ModuleOverlay.Types.CALIBRATION}
       />
     </div>
     <div

--- a/src/renderer/main/user-interface/Tracker.svelte
+++ b/src/renderer/main/user-interface/Tracker.svelte
@@ -92,7 +92,7 @@
       }}
     >
       <Toggle
-        title="Calibration Overlay"
+        title="Calibration"
         on:change={showCalibrationOverlay}
         value={$moduleOverlay === ModuleOverlay.Types.CALIBRATION}
       />

--- a/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
+++ b/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
@@ -35,6 +35,8 @@ export const tooltip_content = {
     "System Events are shared by all Grid modules and Each System Event serves a specific purpose (see the specific system event descriptions).",
   configuration_element_name:
     'Name your control element, by adding an "Element Name" field in Actions.',
+  configuration_calibration:
+    "Enable the calibration overlay to view and manage calibration settings for control elements.",
   configuration_selected_element:
     "A Control Element represents each individual button, knob or fader on a Grid module and are referred to by number from 0 to 15 from topdown left-to-right fashion.",
   configuration_selected_events:

--- a/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
+++ b/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
@@ -177,4 +177,10 @@ export const tooltip_content = {
     "The displayed modules can be repositioned by click and dragging the mouse while holding the control key.",
   tracker_tooltip:
     "When changing a control element, the tracking option determines selection scope.",
+
+  calibration_center: "Move all of the potentiometers on this module to the center position then store the calibration!",
+  calibration_range: "Move all of the analog inputs to the minimum and maximum endpoints before storing the calibration!",
+  calibration_detent_low: "Only use on center-detent potmeters! Slowly rotate the potmeter from the minimum position into the center detent before storing the calibration!",
+  calibration_detent_high: "Only use on center-detent potmeters! Slowly rotate the potmeter from the maximum position into the center detent before storing the calibration!",
+  calibration_reset: "Clear all calibration data on the current module!",
 };

--- a/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
+++ b/src/renderer/main/user-interface/tooltip/tooltip-content.json.js
@@ -178,9 +178,13 @@ export const tooltip_content = {
   tracker_tooltip:
     "When changing a control element, the tracking option determines selection scope.",
 
-  calibration_center: "Move all of the potentiometers on this module to the center position then store the calibration!",
-  calibration_range: "Move all of the analog inputs to the minimum and maximum endpoints before storing the calibration!",
-  calibration_detent_low: "Only use on center-detent potmeters! Slowly rotate the potmeter from the minimum position into the center detent before storing the calibration!",
-  calibration_detent_high: "Only use on center-detent potmeters! Slowly rotate the potmeter from the maximum position into the center detent before storing the calibration!",
+  calibration_center:
+    "Move all of the potentiometers on this module to the center position then store the calibration!",
+  calibration_range:
+    "Move all of the analog inputs to the minimum and maximum endpoints before storing the calibration!",
+  calibration_detent_low:
+    "Only use on center-detent potmeters! Slowly rotate the potmeter from the minimum position into the center detent before storing the calibration!",
+  calibration_detent_high:
+    "Only use on center-detent potmeters! Slowly rotate the potmeter from the maximum position into the center detent before storing the calibration!",
   calibration_reset: "Clear all calibration data on the current module!",
 };

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -292,12 +292,16 @@ export class WriteBuffer implements Readable<WriteBufferData> {
               case ResponseStatus.ERROR: {
                 // Handle "interrupted" errors gracefully - these occur when modules disconnect during operations
                 if (response.error === "Waiting for response was interrupted") {
-                  console.log("Operation interrupted (module disconnected):", response.error);
+                  console.log(
+                    "Operation interrupted (module disconnected):",
+                    response.error,
+                  );
                   logger.set({
                     type: "info",
                     classname: "engine",
                     mode: 0,
-                    message: "Operation interrupted: module disconnected during operation",
+                    message:
+                      "Operation interrupted: module disconnected during operation",
                   });
                   resolve(null); // Resolve gracefully instead of rejecting
                 } else {

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -12,6 +12,7 @@ import { appSettings } from "./app-helper.store";
 import { Subscriber } from "svelte/motion";
 import { ConnectionSimulator } from "./connection-simulator";
 import { MessageStream } from "../serialport/message-stream.store";
+import { logger } from "./runtime.store";
 
 export enum InstructionClassName {
   HEARTBEAT = "HEARTBEAT",
@@ -289,7 +290,19 @@ export class WriteBuffer implements Readable<WriteBufferData> {
                 break;
               }
               case ResponseStatus.ERROR: {
-                reject(response.error);
+                // Handle "interrupted" errors gracefully - these occur when modules disconnect during operations
+                if (response.error === "Waiting for response was interrupted") {
+                  console.log("Operation interrupted (module disconnected):", response.error);
+                  logger.set({
+                    type: "info",
+                    classname: "engine",
+                    mode: 0,
+                    message: "Operation interrupted: module disconnected during operation",
+                  });
+                  resolve(null); // Resolve gracefully instead of rejecting
+                } else {
+                  reject(response.error);
+                }
                 break;
               }
               case ResponseStatus.TIMEOUT: {

--- a/src/renderer/runtime/moduleOverlay.ts
+++ b/src/renderer/runtime/moduleOverlay.ts
@@ -3,6 +3,7 @@ import { writable, Writable } from "svelte/store";
 export namespace ModuleOverlay {
   export enum Types {
     CONTROL_NAME = "control-name-overlay",
+    CALIBRATION = "calibration-overlay",
     PROFILE_LOAD = "profile-load-overlay",
     PRESET_LOAD = "preset-load-overlay",
     PROFILE_DRAG = "profile-drag-overlay",

--- a/src/renderer/serialport/message-stream.store.ts
+++ b/src/renderer/serialport/message-stream.store.ts
@@ -288,6 +288,13 @@ export class MessageStream {
             mode: 0,
             message: Runtime.ErrorText.PAGE_CHANGE_DISABLED,
           });
+        } else if (text.startsWith("INFO:")) {
+          logger.set({
+            type: "info",
+            classname: "debugtext",
+            mode: 0,
+            message: text.substring(5).trim(), // Remove "INFO:" prefix
+          });
         }
       }
 


### PR DESCRIPTION
Test with the following firmware: https://github.com/intechstudio/grid-fw/pull/286
<img width="1280" height="1419" alt="image" src="https://github.com/user-attachments/assets/2975b4b2-dc0f-4cbb-9b4d-72330786fa26" />

 # Calibration System and UI Enhancements

  ## Summary
  Adds a comprehensive calibration system for Grid modules with an interactive overlay UI, plus improvements to the overlay system and debug monitor.

  **Changes:** 18 files changed, 537 insertions(+), 133 deletions(-)

  ## Key Features

  ### Calibration System
  - **New calibration overlay** for modules with proper rotation handling and themed background
  - **Calibration buttons component** with dual modes:
    - Compact mode (horizontal) for Debug Monitor
    - Normal mode (vertical) with i18n tooltips for overlay
  - **Element-specific calibration**:
    - Potentiometers: Center, Range, Detent Low, Detent High
    - Fader: Range only
    - RevH Buttons: Range only
  - **Confirmation dialog** for "Delete Calibration" action
  - **INFO-prefixed logging**: DEBUGTEXT messages with "INFO:" prefix show as toast notifications

  ### Overlay Improvements
  - Unified `--overlay-bg` CSS variable for consistent theming
  - Fixed rotation calculations combining global and per-runtime rotation
  - Improved z-index management using natural DOM stacking
  - Enhanced name overlay with proper theming

  ### Debug Monitor
  - Refactored SendImmediate with Monaco editor and module selection
  - Integrated calibration buttons for selected module
  - Default code: `print("INFO: hello")`

  ### UI Refinements
  - 4px scale-aware gaps between modules in grid layout
  - Light mode toggle moved to top of General settings
  - Graceful handling of interrupted operations

  ## Test Plan
  - [ ] Test calibration overlay on potentiometer and button modules
  - [ ] Verify INFO: messages appear as toast notifications
  - [ ] Test rotation handling at different angles
  - [ ] Verify module gaps scale correctly with zoom
  - [ ] Test SendImmediate module selection and execution

  ## Breaking Changes
  None
