### PR TITLE
Add raw packet send to Debug panel

### DIFF
--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.store.ts
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.store.ts
@@ -105,30 +105,27 @@ function createDebugLowlevel(maxLength: number) {
     },
     push_inbound: (arr) => {
       inbound_data_rate += arr.length;
+      if (freeze) return;
       store.update((d) => {
-        if (freeze == false) {
-          const obj = { data: arr, direction: "IN" };
+        const obj = { data: arr, direction: "IN" };
 
-          if (d.length >= 15) {
-            d.pop();
-          }
-          d = [obj, ...d];
+        if (d.length >= 15) {
+          d.pop();
         }
+        d = [obj, ...d];
         return d;
       });
     },
     push_outbound: (arr) => {
       outbound_data_rate += arr.length;
-
+      if (freeze) return;
       store.update((d) => {
-        if (freeze == false) {
-          let obj = { data: arr, direction: "OUT" };
+        let obj = { data: arr, direction: "OUT" };
 
-          if (d.length >= 15) {
-            d.pop();
-          }
-          d = [obj, ...d];
+        if (d.length >= 15) {
+          d.pop();
         }
+        d = [obj, ...d];
         return d;
       });
     },

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
   import {
-    user_input,
-    type UserInputValue,
-  } from "./../../../runtime/user-input.store";
-  import { GridEvent } from "./../../../runtime/runtime";
-  import { Modal } from "./../../modals/modal.store";
-  import Export from "./../../modals/Export.svelte";
-  import {
     debug_monitor_store,
     debug_lowlevel_store,
     inbound_data_rate_points,
@@ -14,46 +7,18 @@
     inbound_data_rate_history,
     outbound_data_rate_history,
   } from "./DebugMonitor.store";
-  import { appSettings } from "../../../runtime/app-helper.store";
   import { fade } from "svelte/transition";
   import { writable, readable, get } from "svelte/store";
   import PolyLineGraph from "../../user-interface/PolyLineGraph.svelte";
   import { incoming_messages } from "../../../serialport/message-stream.store";
   import { Pane, Splitpanes } from "svelte-splitpanes";
-  import {
-    MoltenPushButton,
-    MoltenInput,
-    MeltRadio,
-  } from "@intechstudio/grid-uikit";
+  import { MoltenPushButton, MeltRadio } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
-  import { Grid } from "../../../lib/_utils";
   import DebugTextList from "./DebugTextList.svelte";
   import { scrollToBottom } from "../../_actions/scroll.move";
   import SendImmediate from "./SendImmediate.svelte";
 
-  let event: GridEvent;
-
-  $: handleUserInputChange($user_input);
-
-  function handleUserInputChange(ui: UserInputValue) {
-    const active = get(runtime_manager).active.runtime;
-    event = active.findEvent(
-      ui.dx,
-      ui.dy,
-      ui.pagenumber,
-      ui.elementnumber,
-      ui.eventtype,
-    );
-  }
-
-  let configScriptLength = 0;
-  let syntaxError = false;
   const incoming_messages_stores = writable([]);
-
-  $: {
-    configScriptLength = $event?.toLua().length ?? 0;
-    syntaxError = $event?.isValid() === false;
-  }
 
   $: if (typeof $incoming_messages !== "undefined") {
     handleIncomingMessage($incoming_messages);
@@ -163,43 +128,12 @@
     });
     return s;
   }
-
-  function handleShowCode() {
-    new Modal.Window(Export).show();
-  }
-
-  let immediateCommand = "print(0,1,2,3)";
 </script>
 
 <config-debug
   transition:fade|global={{ duration: 150 }}
   class="w-full h-full flex flex-col p-4 z-10"
 >
-  <div class="text-white">
-    Editor v{$appSettings.version.major}.{$appSettings.version
-      .minor}.{$appSettings.version.patch}
-  </div>
-
-  <div class="grid grid-cols-[auto_1fr] w-full">
-    <div class="flex flex-col">
-      <div class="text-white">Syntax: {syntaxError}</div>
-      <div class="flex flex-row">
-        <div class="pr-2 text-white">Char Count:</div>
-        <div class="text-white">
-          <span
-            class:text-error={configScriptLength >=
-              Grid.Protocol.maxScriptLength}
-            class:text-yellow-400={configScriptLength >
-              (Grid.Protocol.maxScriptLength / 3) * 2}
-            >{configScriptLength}
-          </span>
-        </div>
-      </div>
-    </div>
-    <div class="flex items-center justify-end">
-      <MoltenPushButton text="Show Code" click={handleShowCode} />
-    </div>
-  </div>
   <SendImmediate />
 
   <Splitpanes

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import {
     MoltenPushButton,
+    MoltenInput,
     MeltSelect,
     Block,
     BlockRow,
-    BlockTitle,
   } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { GridInstruction } from "../../../serialport/instructions";
@@ -15,15 +15,16 @@
   import { logger } from "../../../runtime/runtime.store";
   import { Runtime } from "../../../runtime/string-table";
   import type { ModuleType } from "@intechstudio/grid-protocol";
-  import { grid } from "@intechstudio/grid-protocol";
-  import type { GridModule } from "../../../runtime/runtime";
-  import CalibrationButtons from "./CalibrationButtons.svelte";
+  import { grid, GridScript } from "@intechstudio/grid-protocol";
+  import {
+    InstructionClassName,
+    InstructionClass,
+  } from "../../../runtime/engine.store";
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
   let selectedModule: string = "all";
   let moduleOptions: Array<{ title: string; value: string }> = [];
-  let currentModule: GridModule | undefined = undefined;
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
@@ -95,9 +96,8 @@
     return String(type);
   }
 
-  function sendLuaCode(code: string) {
+  function getActiveRuntime() {
     const runtime = get(runtime_manager).active?.runtime;
-
     if (!runtime) {
       logger.set({
         type: "fail",
@@ -105,30 +105,20 @@
         mode: 0,
         message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
       });
-      return;
     }
+    return runtime;
+  }
 
+  function getSelectedTarget(
+    runtime: import("../../../runtime/runtime").GridRuntime,
+  ): { dx: number; dy: number } | null {
     if (selectedModule === "all") {
-      // Send to all modules
-      const modules = runtime.modules;
-      if (modules.length === 0) {
-        logger.set({
-          type: "fail",
-          classname: "pagechange",
-          mode: 0,
-          message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
-        });
-        return;
-      }
-      modules.forEach((module) => {
-        module.execLUAImmediate(code);
-      });
+      return { dx: -127, dy: -127 };
     } else {
-      // Send to specific module
       const [dxStr, dyStr] = selectedModule.split(",");
-      const dxNum = parseInt(dxStr) || 0;
-      const dyNum = parseInt(dyStr) || 0;
-      const module = runtime.findModule(dxNum, dyNum);
+      const dx = parseInt(dxStr) || 0;
+      const dy = parseInt(dyStr) || 0;
+      const module = runtime.findModule(dx, dy);
       if (!module) {
         logger.set({
           type: "fail",
@@ -136,10 +126,27 @@
           mode: 0,
           message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
         });
-        return;
+        return null;
       }
-      module.execLUAImmediate(code);
+      return { dx, dy };
     }
+  }
+
+  function sendLuaCode(code: string) {
+    const runtime = getActiveRuntime();
+    if (!runtime) return;
+    const target = getSelectedTarget(runtime);
+    if (!target) return;
+
+    const instruction = new GridInstruction.SendConfigImmediate(
+      target.dx,
+      target.dy,
+      GridScript.compressScript(code),
+      runtime.virtual,
+    );
+    instruction.executeOn(runtime.connection).catch((e) => {
+      console.warn(e);
+    });
   }
 
   function handleSendImmediateclicked() {
@@ -147,26 +154,82 @@
     sendLuaCode(value);
   }
 
-  // Get the current module for calibration
-  $: {
-    if (!selectedModule || selectedModule === "all") {
-      currentModule = undefined;
-    } else {
-      const runtime = get(runtime_manager)?.active?.runtime;
-      if (runtime) {
-        const [dxStr, dyStr] = selectedModule.split(",");
-        const dxNum = parseInt(dxStr) || 0;
-        const dyNum = parseInt(dyStr) || 0;
-        currentModule = runtime.findModule(dxNum, dyNum);
-      } else {
-        currentModule = undefined;
-      }
+  let rawInput = `\x02085e001b<?lua print("INFO: foo") ?>\x03`;
+
+  async function handleSendRawClicked() {
+    const runtime = getActiveRuntime();
+    if (!runtime) return;
+    const target = getSelectedTarget(runtime);
+    if (!target) return;
+
+    await sendRawPacket(runtime, target.dx, target.dy);
+  }
+
+  async function sendRawPacket(
+    runtime: import("../../../runtime/runtime").GridRuntime,
+    dx: number,
+    dy: number,
+  ) {
+    // Generate BRC header using a dummy encode_packet call
+    const dummyDescr = {
+      brc_parameters: { DX: dx, DY: dy },
+      class_name: InstructionClassName.IMMEDIATE,
+      class_instr: InstructionClass.EXECUTE,
+      class_parameters: { ACTIONLENGTH: 0, ACTIONSTRING: "" },
+    };
+    const encoded = grid.encode_packet(dummyDescr);
+    if (!encoded) {
+      console.warn("Failed to encode BRC header");
+      return;
+    }
+
+    // Extract BRC header (first 23 bytes: SOH + BRC params + EOB)
+    const brcHeader = encoded.serial.slice(0, 23);
+
+    // Convert raw input string to ASCII code array
+    const classArray: number[] = [];
+    for (let i = 0; i < rawInput.length; i++) {
+      classArray.push(rawInput.charCodeAt(i));
+    }
+
+    // Ensure ETX is followed by EOT
+    if (classArray[classArray.length - 1] === 0x03) {
+      classArray.push(0x04); // EOT
+    } else if (classArray[classArray.length - 1] !== 0x04) {
+      classArray.push(0x03); // ETX
+      classArray.push(0x04); // EOT
+    }
+
+    // Combine BRC header + class section
+    const messageArray = [...brcHeader, ...classArray];
+
+    // Write packet length into BRC LEN field (offset 2, length 4)
+    const len = messageArray.length;
+    const lenHex = len.toString(16).padStart(4, "0");
+    for (let i = 0; i < 4; i++) {
+      messageArray[2 + i] = lenHex.charCodeAt(i);
+    }
+
+    // Calculate XOR checksum
+    const checksum = messageArray.reduce((a, b) => a ^ b);
+    const checksumHex = checksum.toString(16).padStart(2, "0");
+    messageArray.push(checksumHex.charCodeAt(0));
+    messageArray.push(checksumHex.charCodeAt(1));
+
+    // Add newline terminator (required by frame detection)
+    messageArray.push(10);
+
+    // Send through the buffer queue (respects write lock)
+    const data = new Uint8Array(messageArray);
+    try {
+      await runtime.connection.buffer.sendRawToTransport(data);
+    } catch (e) {
+      console.warn("Failed to send raw packet:", e);
     }
   }
 </script>
 
 <Block>
-  <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
   <BlockRow>
     <div class="flex-grow">
       {#key moduleOptions}
@@ -178,11 +241,18 @@
       {/key}
     </div>
     <MoltenPushButton click={refreshModuleList} text="Refresh List" />
+  </BlockRow>
+  <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
+  <BlockRow>
     <MoltenPushButton
       click={handleSendImmediateclicked}
       text="Send Immediate"
     />
   </BlockRow>
-  <BlockTitle>Calibration options</BlockTitle>
-  <CalibrationButtons module={currentModule} onCalibrate={sendLuaCode} />
+  <BlockRow>
+    <div class="flex-grow">
+      <MoltenInput bind:target={rawInput} placeholder="Enter raw command..." />
+    </div>
+    <MoltenPushButton click={handleSendRawClicked} text="Send" />
+  </BlockRow>
 </Block>

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -260,6 +260,14 @@ export class WriteBuffer implements Readable<WriteBufferData> {
     });
   }
 
+  public async sendRawToTransport(data: Uint8Array): Promise<void> {
+    while (this._transport.isWriteLocked()) {
+      await this.sleep(1);
+    }
+    debug_lowlevel_store.push_outbound(Array.from(data));
+    await this._transport.write(data);
+  }
+
   public async waitResponseFromGrid(
     bufferElement: any,
     timeout: number,


### PR DESCRIPTION
## Summary
- Add raw text input with Send button to Debug panel for sending pre-encoded protocol class fields with auto-generated BRC headers
- Refactor Send Immediate and Raw Send to share module address resolution, both using global broadcast for "All Modules"
- Add `sendRawToTransport()` on `WriteBuffer` for raw byte transmission respecting the transport write lock
- Fix freeze not stopping auto-scroll in raw packet viewer
- Clean up DebugMonitor: remove editor version, syntax/char count display, Show Code button, and calibration buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)