### PR TITLE
Improve Export Configurations modal with raw and human-readable views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -266,6 +265,7 @@
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -276,6 +276,7 @@
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -286,6 +287,7 @@
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -296,6 +298,7 @@
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -309,6 +312,7 @@
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.27.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -322,6 +326,7 @@
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -332,6 +337,7 @@
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -342,6 +348,7 @@
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.27.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -355,6 +362,7 @@
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -365,6 +373,7 @@
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -375,6 +384,7 @@
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -385,6 +395,7 @@
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -395,6 +406,7 @@
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -405,6 +417,7 @@
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -415,6 +428,7 @@
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -428,6 +442,7 @@
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -441,6 +456,7 @@
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.27.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -506,7 +522,8 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -802,6 +819,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -821,6 +839,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -836,6 +855,7 @@
       "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -847,6 +867,7 @@
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -857,6 +878,7 @@
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1488,7 +1510,6 @@
     "node_modules/@firebase/app": {
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.18",
         "@firebase/logger": "0.4.4",
@@ -1545,7 +1566,6 @@
     "node_modules/@firebase/app-compat": {
       "version": "0.4.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.2",
         "@firebase/component": "0.6.18",
@@ -1559,8 +1579,7 @@
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.3",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.8",
@@ -1947,7 +1966,6 @@
       "version": "1.12.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2206,6 +2224,7 @@
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -2220,6 +2239,7 @@
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -2227,6 +2247,7 @@
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2238,17 +2259,20 @@
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
       "version": "1.0.3",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2256,6 +2280,7 @@
     "node_modules/@jest/console": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -2271,6 +2296,7 @@
     "node_modules/@jest/core": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/pattern": "30.0.1",
@@ -2316,6 +2342,7 @@
     "node_modules/@jest/diff-sequences": {
       "version": "30.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2323,6 +2350,7 @@
     "node_modules/@jest/environment": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.2.0",
         "@jest/types": "30.2.0",
@@ -2336,6 +2364,7 @@
     "node_modules/@jest/expect": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expect": "30.2.0",
         "jest-snapshot": "30.2.0"
@@ -2347,6 +2376,7 @@
     "node_modules/@jest/expect-utils": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -2357,6 +2387,7 @@
     "node_modules/@jest/fake-timers": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@sinonjs/fake-timers": "^13.0.0",
@@ -2372,6 +2403,7 @@
     "node_modules/@jest/get-type": {
       "version": "30.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2379,6 +2411,7 @@
     "node_modules/@jest/globals": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -2392,6 +2425,7 @@
     "node_modules/@jest/pattern": {
       "version": "30.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -2403,6 +2437,7 @@
     "node_modules/@jest/reporters": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.2.0",
@@ -2443,6 +2478,7 @@
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2450,6 +2486,7 @@
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "10.5.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2468,6 +2505,7 @@
     "node_modules/@jest/reporters/node_modules/minimatch": {
       "version": "9.0.5",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2481,6 +2519,7 @@
     "node_modules/@jest/schemas": {
       "version": "30.0.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -2491,6 +2530,7 @@
     "node_modules/@jest/snapshot-utils": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
@@ -2504,6 +2544,7 @@
     "node_modules/@jest/source-map": {
       "version": "30.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "callsites": "^3.1.0",
@@ -2516,6 +2557,7 @@
     "node_modules/@jest/test-result": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/types": "30.2.0",
@@ -2529,6 +2571,7 @@
     "node_modules/@jest/test-sequencer": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.2.0",
         "graceful-fs": "^4.2.11",
@@ -2542,6 +2585,7 @@
     "node_modules/@jest/transform": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -2566,6 +2610,7 @@
     "node_modules/@jest/types": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -2673,7 +2718,6 @@
     "node_modules/@mixpanel/rrweb": {
       "version": "2.0.0-alpha.18.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mixpanel/rrdom": "^2.0.0-alpha.18",
         "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
@@ -2706,8 +2750,7 @@
     },
     "node_modules/@mixpanel/rrweb-utils": {
       "version": "2.0.0-alpha.18.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2715,6 +2758,7 @@
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -2795,6 +2839,7 @@
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -3212,7 +3257,8 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -3228,6 +3274,7 @@
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -3235,6 +3282,7 @@
     "node_modules/@sinonjs/commons/node_modules/type-detect": {
       "version": "4.0.8",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -3242,6 +3290,7 @@
     "node_modules/@sinonjs/fake-timers": {
       "version": "13.0.5",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -3257,7 +3306,6 @@
       "version": "6.2.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -3313,6 +3361,7 @@
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3320,6 +3369,7 @@
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -3331,6 +3381,7 @@
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -3338,6 +3389,7 @@
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -3346,6 +3398,7 @@
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -3419,11 +3472,13 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -3431,6 +3486,7 @@
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -3492,7 +3548,8 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3517,13 +3574,15 @@
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3536,7 +3595,8 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -3549,7 +3609,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -3562,7 +3623,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -3573,7 +3635,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -3586,7 +3649,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -3599,7 +3663,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -3612,7 +3677,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -3625,7 +3691,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -3638,7 +3705,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -3651,7 +3719,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -3664,7 +3733,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -3677,7 +3747,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -3690,7 +3761,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -3703,7 +3775,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -3716,7 +3789,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -3729,7 +3803,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -3740,6 +3815,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -3758,7 +3834,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -3771,7 +3848,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -3784,7 +3862,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
@@ -3939,7 +4018,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3972,7 +4050,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4035,6 +4112,7 @@
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -4048,6 +4126,7 @@
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4391,6 +4470,7 @@
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -4410,6 +4490,7 @@
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -4427,6 +4508,7 @@
     "node_modules/babel-plugin-jest-hoist": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/babel__core": "^7.20.5"
       },
@@ -4437,6 +4519,7 @@
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -4461,6 +4544,7 @@
     "node_modules/babel-preset-jest": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "30.2.0",
         "babel-preset-current-node-syntax": "^1.2.0"
@@ -4601,7 +4685,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4629,6 +4712,7 @@
     "node_modules/bser": {
       "version": "2.1.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -4891,6 +4975,7 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4948,6 +5033,7 @@
     "node_modules/char-regex": {
       "version": "1.0.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5040,7 +5126,8 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -5121,6 +5208,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -5128,7 +5216,8 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5240,7 +5329,8 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -5414,6 +5504,7 @@
     "node_modules/dedent": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -5510,6 +5601,7 @@
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5619,7 +5711,6 @@
       "version": "26.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.3.0",
         "builder-util": "26.3.0",
@@ -5954,6 +6045,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5972,6 +6064,7 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5985,6 +6078,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5993,6 +6087,7 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6015,6 +6110,7 @@
     "node_modules/emittery": {
       "version": "0.13.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6274,7 +6370,6 @@
     "node_modules/eslint": {
       "version": "9.39.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6435,6 +6530,7 @@
     "node_modules/esprima": {
       "version": "4.0.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -6504,6 +6600,7 @@
     "node_modules/execa": {
       "version": "5.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -6525,6 +6622,7 @@
     "node_modules/execa/node_modules/get-stream": {
       "version": "6.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6535,6 +6633,7 @@
     "node_modules/exit-x": {
       "version": "0.2.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6542,6 +6641,7 @@
     "node_modules/expect": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.2.0",
         "@jest/get-type": "30.1.0",
@@ -6705,6 +6805,7 @@
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -6767,6 +6868,7 @@
     "node_modules/find-up": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -7078,6 +7180,7 @@
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7473,7 +7576,8 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -7550,6 +7654,7 @@
     "node_modules/human-signals": {
       "version": "2.1.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -7631,6 +7736,7 @@
     "node_modules/import-local": {
       "version": "3.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -7849,6 +7955,7 @@
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8132,6 +8239,7 @@
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8139,6 +8247,7 @@
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -8153,6 +8262,7 @@
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -8165,6 +8275,7 @@
     "node_modules/istanbul-lib-source-maps": {
       "version": "5.0.6",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
@@ -8177,6 +8288,7 @@
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -8242,6 +8354,7 @@
     "node_modules/jest-changed-files": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execa": "^5.1.1",
         "jest-util": "30.2.0",
@@ -8254,6 +8367,7 @@
     "node_modules/jest-circus": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -8283,6 +8397,7 @@
     "node_modules/jest-cli": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/test-result": "30.2.0",
@@ -8313,6 +8428,7 @@
     "node_modules/jest-config": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
@@ -8362,6 +8478,7 @@
     "node_modules/jest-config/node_modules/brace-expansion": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8369,6 +8486,7 @@
     "node_modules/jest-config/node_modules/glob": {
       "version": "10.5.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -8387,6 +8505,7 @@
     "node_modules/jest-config/node_modules/minimatch": {
       "version": "9.0.5",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8400,6 +8519,7 @@
     "node_modules/jest-diff": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
@@ -8413,6 +8533,7 @@
     "node_modules/jest-docblock": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "detect-newline": "^3.1.0"
       },
@@ -8423,6 +8544,7 @@
     "node_modules/jest-each": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.2.0",
@@ -8437,6 +8559,7 @@
     "node_modules/jest-environment-node": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -8453,6 +8576,7 @@
     "node_modules/jest-haste-map": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -8475,6 +8599,7 @@
     "node_modules/jest-leak-detector": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "pretty-format": "30.2.0"
@@ -8486,6 +8611,7 @@
     "node_modules/jest-matcher-utils": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -8499,6 +8625,7 @@
     "node_modules/jest-message-util": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.2.0",
@@ -8517,6 +8644,7 @@
     "node_modules/jest-mock": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -8529,6 +8657,7 @@
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -8544,6 +8673,7 @@
     "node_modules/jest-regex-util": {
       "version": "30.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -8551,6 +8681,7 @@
     "node_modules/jest-resolve": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
@@ -8568,6 +8699,7 @@
     "node_modules/jest-resolve-dependencies": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jest-regex-util": "30.0.1",
         "jest-snapshot": "30.2.0"
@@ -8579,6 +8711,7 @@
     "node_modules/jest-runner": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/environment": "30.2.0",
@@ -8610,6 +8743,7 @@
     "node_modules/jest-runner/node_modules/source-map-support": {
       "version": "0.5.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8618,6 +8752,7 @@
     "node_modules/jest-runtime": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -8649,6 +8784,7 @@
     "node_modules/jest-runtime/node_modules/brace-expansion": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8656,6 +8792,7 @@
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "10.5.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -8674,6 +8811,7 @@
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "9.0.5",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8687,6 +8825,7 @@
     "node_modules/jest-snapshot": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -8717,6 +8856,7 @@
     "node_modules/jest-util": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -8732,6 +8872,7 @@
     "node_modules/jest-util/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8742,6 +8883,7 @@
     "node_modules/jest-validate": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.2.0",
@@ -8757,6 +8899,7 @@
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8767,6 +8910,7 @@
     "node_modules/jest-watcher": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8784,6 +8928,7 @@
     "node_modules/jest-worker": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -8798,6 +8943,7 @@
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8812,7 +8958,6 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8859,7 +9004,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8940,6 +9086,7 @@
     "node_modules/leven": {
       "version": "3.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9018,6 +9165,7 @@
     "node_modules/locate-path": {
       "version": "5.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -9093,6 +9241,7 @@
     "node_modules/make-dir": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -9131,6 +9280,7 @@
     "node_modules/makeerror": {
       "version": "1.0.12",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -9173,7 +9323,8 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -9407,6 +9558,7 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9476,6 +9628,7 @@
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "napi-postinstall": "lib/cli.js"
       },
@@ -9651,7 +9804,8 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -9884,6 +10038,7 @@
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -10071,6 +10226,7 @@
     "node_modules/p-locate": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -10081,6 +10237,7 @@
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -10139,6 +10296,7 @@
     "node_modules/parse-json": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10315,6 +10473,7 @@
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -10461,7 +10620,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10525,7 +10683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lilconfig": "^3.0.0",
         "yaml": "^2.3.4"
@@ -10608,6 +10765,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10623,6 +10781,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10638,7 +10797,6 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10661,6 +10819,7 @@
     "node_modules/pretty-format": {
       "version": "30.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -10673,6 +10832,7 @@
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10776,7 +10936,8 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -10823,7 +10984,8 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
@@ -10996,6 +11158,7 @@
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -11006,6 +11169,7 @@
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11639,6 +11803,7 @@
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -11649,6 +11814,7 @@
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11697,6 +11863,7 @@
     "node_modules/string-length": {
       "version": "4.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -11824,6 +11991,7 @@
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11831,6 +11999,7 @@
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11909,7 +12078,6 @@
     "node_modules/svelte": {
       "version": "5.49.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12019,6 +12187,7 @@
     "node_modules/synckit": {
       "version": "0.11.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.9"
       },
@@ -12177,6 +12346,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12198,6 +12368,7 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12208,6 +12379,7 @@
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -12220,6 +12392,7 @@
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "3.1.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12320,7 +12493,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12356,7 +12528,8 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -12546,7 +12719,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12627,6 +12799,7 @@
       "version": "1.11.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -12728,6 +12901,7 @@
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -12769,7 +12943,6 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13333,7 +13506,6 @@
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13453,6 +13625,7 @@
     "node_modules/walker": {
       "version": "1.0.8",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -13684,6 +13857,7 @@
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -13695,6 +13869,7 @@
     "node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "4.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,7 +5,6 @@ import {
   Tray,
   Menu,
   nativeImage,
-  clipboard,
   shell,
   MessageChannelMain,
   utilityProcess,
@@ -826,11 +825,6 @@ function startConfigWatcher(configPath, rootDirectory) {
   });
   sendLocalConfigs();
 }
-
-ipcMain.handle("clipboardWriteText", async (event, arg) => {
-  console.log(arg.text);
-  clipboard.writeText(arg.text);
-});
 
 ipcMain.handle("download", async (event, arg) => {
   let result: any = undefined;

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -42,9 +42,6 @@ contextBridge.exposeInMainWorld("electron", {
     restartSerialCheckInterval: () =>
       ipcRenderer.invoke("restartSerialCheckInterval"),
   },
-  clipboard: {
-    writeText: (text) => ipcRenderer.invoke("clipboardWriteText", { text }),
-  },
   configs: {
     migrateToProfileCloud: (oldRootPath, newRootPath, configDirectory) =>
       ipcRenderer.invoke("migrateToProfileCloud", {

--- a/src/renderer/main/modals/Export.svelte
+++ b/src/renderer/main/modals/Export.svelte
@@ -11,6 +11,7 @@
   } from "./../../runtime/user-input.store";
   import { runtime_manager } from "../../runtime/runtime-manager.store";
   import MoltenIconButton from "../user-interface/MoltenIconButton.svelte";
+  import { GridScript } from "@intechstudio/grid-protocol";
 
   export let data: Modal.Instance;
 
@@ -29,22 +30,15 @@
     );
   }
 
-  function handleCopy() {
-    const _tempSpan = document.createElement("input");
-    _tempSpan.value = get(event).toLua();
+  $: rawCode = $event?.toLua() ?? "";
+  $: humanReadable = GridScript.expandScript(rawCode);
 
-    _tempSpan.id = "temp-clip";
-    document.getElementById("modal-copy-placeholder").append(_tempSpan);
-    const _temp = document.querySelector("#temp-clip");
-    _temp.select();
-    document.execCommand("copy");
-    document.getElementById("temp-clip").remove();
+  function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
   }
 </script>
 
-<div id="modal-copy-placeholder" />
-
-<MoltenModal {data}>
+<MoltenModal {data} width="700px">
   <div slot="content" class="flex flex-col gap-2 items-center">
     <div class="w-full flex justify-between items-center">
       <div class="text-foreground-muted text-sm pb-1">
@@ -61,15 +55,44 @@
       </div>
     </div>
 
-    <textarea
-      value={$event.toLua()}
-      readonly
-      rows="12"
-      class="min-h-200 font-mono w-full p-1 my-1 rounded bg-background-muted whitespace-pre-wrap resize"
-    />
+    <div class="w-full flex flex-row gap-3">
+      <div class="flex-1 flex flex-col gap-1">
+        <div class="text-foreground-muted text-xs">Raw code</div>
+        <textarea
+          value={rawCode}
+          readonly
+          rows="18"
+          class="font-mono w-full p-1 rounded bg-background-muted whitespace-pre-wrap resize"
+        />
+        <div class="flex justify-end">
+          <MoltenPushButton
+            click={() => copyToClipboard(rawCode)}
+            text="Copy"
+            style="accept"
+          >
+            <MoltenPopup slot="popup" text="Copied to clipboard!" />
+          </MoltenPushButton>
+        </div>
+      </div>
 
-    <MoltenPushButton click={handleCopy} text="Copy" style="accept">
-      <MoltenPopup slot="popup" text="Copied to clipboard!" />
-    </MoltenPushButton>
+      <div class="flex-1 flex flex-col gap-1">
+        <div class="text-foreground-muted text-xs">Human readable</div>
+        <textarea
+          value={humanReadable}
+          readonly
+          rows="18"
+          class="font-mono w-full p-1 rounded bg-background-muted whitespace-pre-wrap resize"
+        />
+        <div class="flex justify-end">
+          <MoltenPushButton
+            click={() => copyToClipboard(humanReadable)}
+            text="Copy"
+            style="accept"
+          >
+            <MoltenPopup slot="popup" text="Copied to clipboard!" />
+          </MoltenPushButton>
+        </div>
+      </div>
+    </div>
   </div>
 </MoltenModal>

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -152,7 +152,7 @@
   }
 
   async function handleCreateCloudConfigLink(event) {
-    return await window.electron.clipboard.writeText(event.data.configLinkUrl);
+    return await navigator.clipboard.writeText(event.data.configLinkUrl);
   }
 
   async function handleLogoutFromProfileCloud(event) {

--- a/src/renderer/preload-window-config.ts
+++ b/src/renderer/preload-window-config.ts
@@ -50,13 +50,6 @@ if (import.meta.env.VITE_BUILD_TARGET == "web") {
       restore: () => {},
       isMaximized: () => {},
     },
-    clipboard: {
-      writeText: () => {
-        return new Promise((resolve, reject) => {
-          reject("This feature is not yet supported in web mode.");
-        });
-      },
-    },
     persistentStorage: {
       set: () => {},
       get: async () => {


### PR DESCRIPTION
## Summary

- Display both raw code and human-readable (expanded) Lua side by side in the Export Configurations modal
- Replace legacy `execCommand` clipboard hack with `navigator.clipboard.writeText`
- Migrate ProfileCloud config link copy to `navigator.clipboard` and remove the now-unused `window.electron.clipboard` IPC path

## Test plan

- [ ] Open Export Configurations modal and verify both "Raw code" and "Human readable" panels appear side by side
- [ ] Verify Copy button on each panel copies the correct content with newlines preserved
- [ ] Verify Profile Cloud "copy config link" still works
- [ ] Confirm no regressions in other clipboard-related features

🤖 Generated with [Claude Code](https://claude.com/claude-code)