### PR TITLE
Fix dependabot workflow failures caused by inaccessible secrets

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -34,7 +34,7 @@ jobs:
           target: grid-editor
 
       - name: Deploy to Firebase Hosting on pull request
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "**"
+      - "!dependabot/**"
     tags-ignore:
       - "*"
 


### PR DESCRIPTION
## Summary

Dependabot runs in an isolated security context and cannot access repository/organization secrets by design. This caused two workflows to always fail on dependabot branches/PRs:

- **Nightly build** — `electron-builder` failed on macOS and Windows because code signing secrets (`CSC_LINK`, `AZURE_TENANT_ID`, etc.) were empty
- **Firebase Hosting** — deploy step failed with `Input required and not supplied: firebaseServiceAccount`

## Changes

- Exclude `dependabot/**` branches from the nightly build trigger
- Skip Firebase Hosting preview deploy when the actor is `dependabot[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)