### PR TITLE
Add EVALUATE debug panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.5",
       "hasInstallScript": true,
       "dependencies": {
-        "@intechstudio/grid-protocol": "1.20260131.1058",
+        "@intechstudio/grid-protocol": "^1.20260302.1321",
         "@intechstudio/grid-uikit": "^1.20260206.1447",
         "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
         "adm-zip": "^0.5.10",
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/@intechstudio/grid-protocol": {
-      "version": "1.20260131.1058",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260131.1058.tgz",
-      "integrity": "sha512-+C2FNAbWVZQWqC/wkHvdfaMon1MnIU8DFHyxQiZXVL7wA79UGY3erxtlG8shjY8q+AIANZXIsq3eeBhkjgFDYw==",
+      "version": "1.20260302.1321",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260302.1321.tgz",
+      "integrity": "sha512-NOsq4uO7W9BnmF77GTOfv8CWClKCSU+cl6M/OZkdOGQEnLZ+gQrRSOWKQ4wBdGtMY+U9PfZjpCU8LHU2MwM9ng==",
       "dependencies": {
         "@wasm-fmt/lua_fmt": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@intechstudio/grid-protocol": "1.20260131.1058",
+    "@intechstudio/grid-protocol": "^1.20260302.1321",
     "@intechstudio/grid-uikit": "^1.20260206.1447",
     "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
     "adm-zip": "^0.5.10",

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -8,15 +8,19 @@
     outbound_data_rate_history,
   } from "./DebugMonitor.store";
   import { fade } from "svelte/transition";
+  import { onMount } from "svelte";
   import { writable, readable, get } from "svelte/store";
   import PolyLineGraph from "../../user-interface/PolyLineGraph.svelte";
   import { incoming_messages } from "../../../serialport/message-stream.store";
   import { Pane, Splitpanes } from "svelte-splitpanes";
-  import { MoltenPushButton, MeltRadio } from "@intechstudio/grid-uikit";
+  import { MoltenPushButton, MeltRadio, MeltSelect } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
+  import type { ModuleType } from "@intechstudio/grid-protocol";
   import DebugTextList from "./DebugTextList.svelte";
   import { scrollToBottom } from "../../_actions/scroll.move";
   import SendImmediate from "./SendImmediate.svelte";
+  import SendEvaluate from "./SendEvaluate.svelte";
+  import SendRaw from "./SendRaw.svelte";
 
   const incoming_messages_stores = writable([]);
 
@@ -54,6 +58,47 @@
   }
 
   let display = "CHAR";
+  let selectedSend = "immediate";
+
+  let selectedModule: string = "all";
+  let moduleOptions: Array<{ title: string; value: string }> = [];
+
+  function getModuleTypeName(type: ModuleType): string {
+    if (typeof type === "object" && type.type) return type.type;
+    return String(type);
+  }
+
+  function refreshModuleList() {
+    const runtime = get(runtime_manager)?.active?.runtime;
+    const modules = runtime?.modules || [];
+
+    const newOptions = [
+      { title: "All Modules (Global)", value: "all" },
+      ...modules.map((module) => ({
+        title: `Module [${module.dx}, ${module.dy}] - ${getModuleTypeName(module.type)}`,
+        value: `${module.dx},${module.dy}`,
+      })),
+    ];
+
+    if (selectedModule !== "all") {
+      const exists = newOptions.some((opt) => opt.value === selectedModule);
+      if (!exists) selectedModule = "all";
+    }
+
+    moduleOptions = newOptions;
+  }
+
+  onMount(() => {
+    refreshModuleList();
+  });
+
+  $: target =
+    !selectedModule || selectedModule === "all"
+      ? { dx: -127, dy: -127 }
+      : (() => {
+          const [dxStr, dyStr] = selectedModule.split(",");
+          return { dx: parseInt(dxStr) || 0, dy: parseInt(dyStr) || 0 };
+        })();
 
   function average(arr) {
     let sum = 0;
@@ -134,7 +179,39 @@
   transition:fade|global={{ duration: 150 }}
   class="w-full h-full flex flex-col p-4 z-10"
 >
-  <SendImmediate />
+  <div class="flex flex-row gap-2 mb-2">
+    <div class="flex-grow">
+      {#key moduleOptions}
+        <MeltSelect
+          bind:target={selectedModule}
+          options={moduleOptions}
+          disabled={false}
+        />
+      {/key}
+    </div>
+    <MoltenPushButton click={refreshModuleList} text="Refresh" />
+  </div>
+
+  <div class="flex mb-2">
+    <MeltRadio
+      bind:target={selectedSend}
+      style="button"
+      orientation="horizontal"
+      options={[
+        { title: "Immediate", value: "immediate" },
+        { title: "Evaluate", value: "evaluate" },
+        { title: "Raw", value: "raw" },
+      ]}
+    />
+  </div>
+
+  {#if selectedSend === "immediate"}
+    <SendImmediate {target} />
+  {:else if selectedSend === "evaluate"}
+    <SendEvaluate {target} />
+  {:else if selectedSend === "raw"}
+    <SendRaw {target} />
+  {/if}
 
   <Splitpanes
     theme="modern-theme"

--- a/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
+++ b/src/renderer/main/panels/DebugMonitor/DebugMonitor.svelte
@@ -13,7 +13,11 @@
   import PolyLineGraph from "../../user-interface/PolyLineGraph.svelte";
   import { incoming_messages } from "../../../serialport/message-stream.store";
   import { Pane, Splitpanes } from "svelte-splitpanes";
-  import { MoltenPushButton, MeltRadio, MeltSelect } from "@intechstudio/grid-uikit";
+  import {
+    MoltenPushButton,
+    MeltRadio,
+    MeltSelect,
+  } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import type { ModuleType } from "@intechstudio/grid-protocol";
   import DebugTextList from "./DebugTextList.svelte";
@@ -58,7 +62,7 @@
   }
 
   let display = "CHAR";
-  let selectedSend = "immediate";
+  let selectedSend = "evaluate";
 
   let selectedModule: string = "all";
   let moduleOptions: Array<{ title: string; value: string }> = [];
@@ -198,8 +202,8 @@
       style="button"
       orientation="horizontal"
       options={[
-        { title: "Immediate", value: "immediate" },
         { title: "Evaluate", value: "evaluate" },
+        { title: "Immediate", value: "immediate" },
         { title: "Raw", value: "raw" },
       ]}
     />

--- a/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { MoltenPushButton, Block, BlockRow } from "@intechstudio/grid-uikit";
+  import { runtime_manager } from "../../../runtime/runtime-manager.store";
+  import { onMount } from "svelte";
+  import { MonacoEditor } from "../../../lib/monaco";
+  import { appSettings } from "../../../runtime/app-helper.store";
+  import { get } from "svelte/store";
+  import { grid, GridScript } from "@intechstudio/grid-protocol";
+  import {
+    InstructionClassName,
+    InstructionClass,
+    ResponseStatus,
+  } from "../../../runtime/engine.store";
+  import {
+    parseEvaluateResponse,
+    type LuaValue,
+  } from "../../../serialport/evaluate-parser";
+
+  export let target: { dx: number; dy: number };
+
+  let monacoElement: HTMLElement;
+  let editor: MonacoEditor.CustomCodeEditor;
+
+  let pending = false;
+  let status: "ACK" | "NACK" | "TIMEOUT" | null = null;
+  let messageId: string | null = null;
+  let responseValues: LuaValue[] | null = null;
+
+  onMount(() => {
+    editor = MonacoEditor.create(monacoElement, {
+      value: "return nil",
+      language: "lua",
+      theme: $appSettings.persistent.lightMode
+        ? MonacoEditor.Theme.LIGHT
+        : MonacoEditor.Theme.DARK,
+      fontSize: $appSettings.persistent.fontSize,
+      folding: false,
+      renderLineHighlight: "none",
+      contextmenu: false,
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+      wordWrap: "on",
+      suggest: { showIcons: false, showWords: true },
+      minimap: { enabled: false },
+      lineNumbers: "off",
+    });
+  });
+
+  $: if (editor) {
+    MonacoEditor.setTheme(
+      $appSettings.persistent.lightMode
+        ? MonacoEditor.Theme.LIGHT
+        : MonacoEditor.Theme.DARK,
+    );
+  }
+
+  async function handleSendEvaluate() {
+    const runtime = get(runtime_manager).active?.runtime;
+    if (!runtime) return;
+
+    const code = editor.getValue();
+    const script = `<?lua ${GridScript.compressScript(code)} ?>`;
+    const size = script.length.toString(16).padStart(4, "0");
+
+    const classBody = `\x02086e0001` + `04` + size + script + `\x03`;
+    const classArray: number[] = Array.from(classBody, (c) => c.charCodeAt(0));
+    classArray.push(0x04);
+
+    const dummyDescr = {
+      brc_parameters: { DX: target.dx, DY: target.dy },
+      class_name: InstructionClassName.IMMEDIATE,
+      class_instr: InstructionClass.EXECUTE,
+      class_parameters: { ACTIONLENGTH: 0, ACTIONSTRING: "" },
+    };
+    const encoded = grid.encode_packet(dummyDescr);
+    if (!encoded) return;
+
+    const brcHeader: number[] = encoded.serial.slice(0, 23);
+    const messageArray: number[] = [...brcHeader, ...classArray];
+
+    const lenHex = messageArray.length.toString(16).padStart(4, "0");
+    for (let i = 0; i < 4; i++) {
+      messageArray[2 + i] = lenHex.charCodeAt(i);
+    }
+
+    const checksum = messageArray.reduce((a, b) => a ^ b);
+    const checksumHex = checksum.toString(16).padStart(2, "0");
+    messageArray.push(checksumHex.charCodeAt(0));
+    messageArray.push(checksumHex.charCodeAt(1));
+    messageArray.push(10);
+
+    pending = true;
+    status = null;
+    messageId = null;
+    responseValues = null;
+
+    try {
+      await runtime.connection.buffer.sendRawToTransport(
+        new Uint8Array(messageArray),
+      );
+
+      const response = await runtime.connection.buffer.waitResponseFromGrid(
+        { filter: { class_name: "EVALUATE", brc_parameters: {}, class_parameters: {} } },
+        2000,
+      );
+
+      if (response.status === ResponseStatus.TIMEOUT) {
+        status = "TIMEOUT";
+      } else if (response.status === ResponseStatus.OK) {
+        const descr = response.data;
+        status = descr.class_instr === "REPORT" ? "ACK" : "NACK";
+        messageId = descr.class_parameters.LASTHEADER;
+        responseValues = parseEvaluateResponse(descr);
+      }
+    } catch (e) {
+      console.warn("Evaluate failed:", e);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<Block>
+  <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
+  <BlockRow>
+    <MoltenPushButton
+      click={handleSendEvaluate}
+      text={pending ? "Waiting..." : "Send Evaluate"}
+      disabled={pending}
+    />
+  </BlockRow>
+
+  {#if pending || status !== null}
+    <div class="flex flex-col gap-1 mt-1 font-mono text-sm">
+      <div class="flex gap-3 items-center">
+        <span
+          class={status === "ACK"
+            ? "text-green-400"
+            : status === "NACK"
+              ? "text-red-400"
+              : status === "TIMEOUT"
+                ? "text-yellow-400"
+                : "text-gray-400"}
+        >
+          {pending ? "pending" : status}
+        </span>
+        {#if messageId !== null}
+          <span class="text-gray-400">id: {messageId}</span>
+        {/if}
+      </div>
+      {#if responseValues !== null}
+        <pre class="text-white whitespace-pre-wrap break-all">{JSON.stringify(responseValues, null, 2)}</pre>
+      {/if}
+    </div>
+  {/if}
+</Block>

--- a/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
@@ -9,7 +9,6 @@
   import {
     InstructionClassName,
     InstructionClass,
-    ResponseStatus,
   } from "../../../runtime/engine.store";
   import {
     parseEvaluateResponse,
@@ -22,7 +21,7 @@
   let editor: MonacoEditor.CustomCodeEditor;
 
   let pending = false;
-  let status: "ACK" | "NACK" | "TIMEOUT" | null = null;
+  let status: "ACK" | "NACK" | null = null;
   let messageId: string | null = null;
   let responseValues: LuaValue[] | null = null;
 
@@ -95,23 +94,21 @@
     responseValues = null;
 
     try {
-      await runtime.connection.buffer.sendRawToTransport(
+      const descr = await runtime.connection.buffer.sendRawDataToGrid(
         new Uint8Array(messageArray),
+        {
+          responseRequired: true,
+          filter: {
+            class_name: "EVALUATE",
+            brc_parameters: {},
+            class_parameters: {},
+          },
+          responseTimeout: 2000,
+        },
       );
-
-      const response = await runtime.connection.buffer.waitResponseFromGrid(
-        { filter: { class_name: "EVALUATE", brc_parameters: {}, class_parameters: {} } },
-        2000,
-      );
-
-      if (response.status === ResponseStatus.TIMEOUT) {
-        status = "TIMEOUT";
-      } else if (response.status === ResponseStatus.OK) {
-        const descr = response.data;
-        status = descr.class_instr === "REPORT" ? "ACK" : "NACK";
-        messageId = descr.class_parameters.LASTHEADER;
-        responseValues = parseEvaluateResponse(descr);
-      }
+      status = descr.class_instr === "REPORT" ? "ACK" : "NACK";
+      messageId = descr.class_parameters.LASTHEADER;
+      responseValues = parseEvaluateResponse(descr);
     } catch (e) {
       console.warn("Evaluate failed:", e);
     } finally {
@@ -138,9 +135,7 @@
             ? "text-green-400"
             : status === "NACK"
               ? "text-red-400"
-              : status === "TIMEOUT"
-                ? "text-yellow-400"
-                : "text-gray-400"}
+              : "text-gray-400"}
         >
           {pending ? "pending" : status}
         </span>
@@ -149,7 +144,11 @@
         {/if}
       </div>
       {#if responseValues !== null}
-        <pre class="text-white whitespace-pre-wrap break-all">{JSON.stringify(responseValues, null, 2)}</pre>
+        <pre class="text-white whitespace-pre-wrap break-all">{JSON.stringify(
+            responseValues,
+            null,
+            2,
+          )}</pre>
       {/if}
     </div>
   {/if}

--- a/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
@@ -97,6 +97,8 @@
       const descr = await runtime.connection.buffer.sendRawDataToGrid(
         new Uint8Array(messageArray),
         {
+          dx: target.dx,
+          dy: target.dy,
           responseRequired: true,
           filter: {
             class_name: "EVALUATE",

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -60,6 +60,9 @@
 <Block>
   <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
   <BlockRow>
-    <MoltenPushButton click={handleSendImmediateclicked} text="Send Immediate" />
+    <MoltenPushButton
+      click={handleSendImmediateclicked}
+      text="Send Immediate"
+    />
   </BlockRow>
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendImmediate.svelte
@@ -1,30 +1,17 @@
 <script lang="ts">
-  import {
-    MoltenPushButton,
-    MoltenInput,
-    MeltSelect,
-    Block,
-    BlockRow,
-  } from "@intechstudio/grid-uikit";
+  import { MoltenPushButton, Block, BlockRow } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { GridInstruction } from "../../../serialport/instructions";
   import { onMount } from "svelte";
   import { MonacoEditor } from "../../../lib/monaco";
   import { appSettings } from "../../../runtime/app-helper.store";
   import { get } from "svelte/store";
-  import { logger } from "../../../runtime/runtime.store";
-  import { Runtime } from "../../../runtime/string-table";
-  import type { ModuleType } from "@intechstudio/grid-protocol";
-  import { grid, GridScript } from "@intechstudio/grid-protocol";
-  import {
-    InstructionClassName,
-    InstructionClass,
-  } from "../../../runtime/engine.store";
+  import { GridScript } from "@intechstudio/grid-protocol";
+
+  export let target: { dx: number; dy: number };
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
-  let selectedModule: string = "all";
-  let moduleOptions: Array<{ title: string; value: string }> = [];
 
   onMount(() => {
     editor = MonacoEditor.create(monacoElement, {
@@ -40,219 +27,39 @@
       scrollBeyondLastLine: false,
       automaticLayout: true,
       wordWrap: "on",
-      suggest: {
-        showIcons: false,
-        showWords: true,
-      },
-      minimap: {
-        enabled: false,
-      },
+      suggest: { showIcons: false, showWords: true },
+      minimap: { enabled: false },
       lineNumbers: "off",
     });
-
-    // Initial module list population
-    refreshModuleList();
   });
 
   $: if (editor) {
-    handleLightModeChange($appSettings.persistent.lightMode);
-  }
-
-  function handleLightModeChange(value: boolean) {
     MonacoEditor.setTheme(
-      value ? MonacoEditor.Theme.LIGHT : MonacoEditor.Theme.DARK,
+      $appSettings.persistent.lightMode
+        ? MonacoEditor.Theme.LIGHT
+        : MonacoEditor.Theme.DARK,
     );
   }
 
-  function refreshModuleList() {
-    const runtime = get(runtime_manager)?.active?.runtime;
-    const modules = runtime?.modules || [];
-
-    const newOptions = [
-      { title: "All Modules (Global)", value: "all" },
-      ...modules.map((module) => ({
-        title: `Module [${module.dx}, ${module.dy}] - ${getModuleTypeName(module.type)}`,
-        value: `${module.dx},${module.dy}`,
-      })),
-    ];
-
-    // Check if selected module still exists
-    if (selectedModule !== "all") {
-      const selectedExists = newOptions.some(
-        (opt) => opt.value === selectedModule,
-      );
-      if (!selectedExists) {
-        selectedModule = "all";
-      }
-    }
-
-    moduleOptions = newOptions;
-  }
-
-  function getModuleTypeName(type: ModuleType): string {
-    if (typeof type === "object" && type.type) {
-      return type.type;
-    }
-    return String(type);
-  }
-
-  function getActiveRuntime() {
+  function handleSendImmediateclicked() {
     const runtime = get(runtime_manager).active?.runtime;
-    if (!runtime) {
-      logger.set({
-        type: "fail",
-        classname: "pagechange",
-        mode: 0,
-        message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
-      });
-    }
-    return runtime;
-  }
-
-  function getSelectedTarget(
-    runtime: import("../../../runtime/runtime").GridRuntime,
-  ): { dx: number; dy: number } | null {
-    if (selectedModule === "all") {
-      return { dx: -127, dy: -127 };
-    } else {
-      const [dxStr, dyStr] = selectedModule.split(",");
-      const dx = parseInt(dxStr) || 0;
-      const dy = parseInt(dyStr) || 0;
-      const module = runtime.findModule(dx, dy);
-      if (!module) {
-        logger.set({
-          type: "fail",
-          classname: "pagechange",
-          mode: 0,
-          message: Runtime.ErrorText.SEND_IMMEDIATE_NO_ACTIVE_MODULE,
-        });
-        return null;
-      }
-      return { dx, dy };
-    }
-  }
-
-  function sendLuaCode(code: string) {
-    const runtime = getActiveRuntime();
     if (!runtime) return;
-    const target = getSelectedTarget(runtime);
-    if (!target) return;
 
     const instruction = new GridInstruction.SendConfigImmediate(
       target.dx,
       target.dy,
-      GridScript.compressScript(code),
+      GridScript.compressScript(editor.getValue()),
       runtime.virtual,
     );
     instruction.executeOn(runtime.connection).catch((e) => {
       console.warn(e);
     });
   }
-
-  function handleSendImmediateclicked() {
-    const value = editor.getValue();
-    sendLuaCode(value);
-  }
-
-  let rawInput = `\x02085e001b<?lua print("INFO: foo") ?>\x03`;
-
-  async function handleSendRawClicked() {
-    const runtime = getActiveRuntime();
-    if (!runtime) return;
-    const target = getSelectedTarget(runtime);
-    if (!target) return;
-
-    await sendRawPacket(runtime, target.dx, target.dy);
-  }
-
-  async function sendRawPacket(
-    runtime: import("../../../runtime/runtime").GridRuntime,
-    dx: number,
-    dy: number,
-  ) {
-    // Generate BRC header using a dummy encode_packet call
-    const dummyDescr = {
-      brc_parameters: { DX: dx, DY: dy },
-      class_name: InstructionClassName.IMMEDIATE,
-      class_instr: InstructionClass.EXECUTE,
-      class_parameters: { ACTIONLENGTH: 0, ACTIONSTRING: "" },
-    };
-    const encoded = grid.encode_packet(dummyDescr);
-    if (!encoded) {
-      console.warn("Failed to encode BRC header");
-      return;
-    }
-
-    // Extract BRC header (first 23 bytes: SOH + BRC params + EOB)
-    const brcHeader = encoded.serial.slice(0, 23);
-
-    // Convert raw input string to ASCII code array
-    const classArray: number[] = [];
-    for (let i = 0; i < rawInput.length; i++) {
-      classArray.push(rawInput.charCodeAt(i));
-    }
-
-    // Ensure ETX is followed by EOT
-    if (classArray[classArray.length - 1] === 0x03) {
-      classArray.push(0x04); // EOT
-    } else if (classArray[classArray.length - 1] !== 0x04) {
-      classArray.push(0x03); // ETX
-      classArray.push(0x04); // EOT
-    }
-
-    // Combine BRC header + class section
-    const messageArray = [...brcHeader, ...classArray];
-
-    // Write packet length into BRC LEN field (offset 2, length 4)
-    const len = messageArray.length;
-    const lenHex = len.toString(16).padStart(4, "0");
-    for (let i = 0; i < 4; i++) {
-      messageArray[2 + i] = lenHex.charCodeAt(i);
-    }
-
-    // Calculate XOR checksum
-    const checksum = messageArray.reduce((a, b) => a ^ b);
-    const checksumHex = checksum.toString(16).padStart(2, "0");
-    messageArray.push(checksumHex.charCodeAt(0));
-    messageArray.push(checksumHex.charCodeAt(1));
-
-    // Add newline terminator (required by frame detection)
-    messageArray.push(10);
-
-    // Send through the buffer queue (respects write lock)
-    const data = new Uint8Array(messageArray);
-    try {
-      await runtime.connection.buffer.sendRawToTransport(data);
-    } catch (e) {
-      console.warn("Failed to send raw packet:", e);
-    }
-  }
 </script>
 
 <Block>
-  <BlockRow>
-    <div class="flex-grow">
-      {#key moduleOptions}
-        <MeltSelect
-          bind:target={selectedModule}
-          options={moduleOptions}
-          disabled={false}
-        />
-      {/key}
-    </div>
-    <MoltenPushButton click={refreshModuleList} text="Refresh List" />
-  </BlockRow>
   <div class="flex w-full h-28 border border-black" bind:this={monacoElement} />
   <BlockRow>
-    <MoltenPushButton
-      click={handleSendImmediateclicked}
-      text="Send Immediate"
-    />
-  </BlockRow>
-  <BlockRow>
-    <div class="flex-grow">
-      <MoltenInput bind:target={rawInput} placeholder="Enter raw command..." />
-    </div>
-    <MoltenPushButton click={handleSendRawClicked} text="Send" />
+    <MoltenPushButton click={handleSendImmediateclicked} text="Send Immediate" />
   </BlockRow>
 </Block>

--- a/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { MoltenPushButton, MoltenInput, Block, BlockRow } from "@intechstudio/grid-uikit";
+  import {
+    MoltenPushButton,
+    MoltenInput,
+    Block,
+    BlockRow,
+  } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import { get } from "svelte/store";
   import { grid } from "@intechstudio/grid-protocol";
@@ -53,7 +58,7 @@
     messageArray.push(10);
 
     try {
-      await runtime.connection.buffer.sendRawToTransport(
+      await runtime.connection.buffer.sendRawDataToGrid(
         new Uint8Array(messageArray),
       );
     } catch (e) {

--- a/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
@@ -60,6 +60,7 @@
     try {
       await runtime.connection.buffer.sendRawDataToGrid(
         new Uint8Array(messageArray),
+        { dx: target.dx, dy: target.dy },
       );
     } catch (e) {
       console.warn("Failed to send raw packet:", e);

--- a/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { MoltenPushButton, MoltenInput, Block, BlockRow } from "@intechstudio/grid-uikit";
+  import { runtime_manager } from "../../../runtime/runtime-manager.store";
+  import { get } from "svelte/store";
+  import { grid } from "@intechstudio/grid-protocol";
+  import {
+    InstructionClassName,
+    InstructionClass,
+  } from "../../../runtime/engine.store";
+
+  export let target: { dx: number; dy: number };
+
+  let rawInput = `\x02085e001b<?lua print("INFO: foo") ?>\x03`;
+
+  async function handleSendRawClicked() {
+    const runtime = get(runtime_manager).active?.runtime;
+    if (!runtime) return;
+
+    const dummyDescr = {
+      brc_parameters: { DX: target.dx, DY: target.dy },
+      class_name: InstructionClassName.IMMEDIATE,
+      class_instr: InstructionClass.EXECUTE,
+      class_parameters: { ACTIONLENGTH: 0, ACTIONSTRING: "" },
+    };
+    const encoded = grid.encode_packet(dummyDescr);
+    if (!encoded) return;
+
+    const brcHeader: number[] = encoded.serial.slice(0, 23);
+
+    const classArray: number[] = [];
+    for (let i = 0; i < rawInput.length; i++) {
+      classArray.push(rawInput.charCodeAt(i));
+    }
+
+    if (classArray[classArray.length - 1] === 0x03) {
+      classArray.push(0x04);
+    } else if (classArray[classArray.length - 1] !== 0x04) {
+      classArray.push(0x03);
+      classArray.push(0x04);
+    }
+
+    const messageArray: number[] = [...brcHeader, ...classArray];
+
+    const lenHex = messageArray.length.toString(16).padStart(4, "0");
+    for (let i = 0; i < 4; i++) {
+      messageArray[2 + i] = lenHex.charCodeAt(i);
+    }
+
+    const checksum = messageArray.reduce((a, b) => a ^ b);
+    const checksumHex = checksum.toString(16).padStart(2, "0");
+    messageArray.push(checksumHex.charCodeAt(0));
+    messageArray.push(checksumHex.charCodeAt(1));
+    messageArray.push(10);
+
+    try {
+      await runtime.connection.buffer.sendRawToTransport(
+        new Uint8Array(messageArray),
+      );
+    } catch (e) {
+      console.warn("Failed to send raw packet:", e);
+    }
+  }
+</script>
+
+<Block>
+  <BlockRow>
+    <div class="flex-grow">
+      <MoltenInput bind:target={rawInput} placeholder="Enter raw command..." />
+    </div>
+    <MoltenPushButton click={handleSendRawClicked} text="Send" />
+  </BlockRow>
+</Block>

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -70,6 +70,8 @@ export type BufferElement = {
   responseTimeout?: number;
   // Response required and send immediate can not be used together
   sendImmediate?: boolean;
+  // If set, these bytes are sent as-is instead of encoding via grid.encode_packet.
+  rawBytes?: Uint8Array;
   filter?: {
     PAGEDISCARD_ACKNOWLEDGE?: {
       LASTHEADER: unknown;
@@ -233,39 +235,52 @@ export class WriteBuffer implements Readable<WriteBufferData> {
     waiter = undefined;
   }
 
-  public sendDataToGrid(descr: any): Promise<any> {
+  public sendDataToGrid(descr: any, rawBytes?: Uint8Array): Promise<any> {
     return new Promise((resolve, reject) => {
-      let retval: any = grid.encode_packet(descr);
+      let serial: number[];
+      let id: any = null;
 
-      // Add newline terminator for Grid protocol framing
-      retval.serial.push(10);
+      if (rawBytes) {
+        serial = Array.from(rawBytes);
+      } else {
+        const retval: any = grid.encode_packet(descr);
+        retval.serial.push(10);
+        serial = retval.serial;
+        id = retval.id;
+      }
 
-      // Debug logging
-      debug_lowlevel_store.push_outbound(retval.serial);
-
-      const data = new Uint8Array(retval.serial);
+      debug_lowlevel_store.push_outbound(serial);
 
       this._transport
-        .write(data)
-        .then(() => {
-          // debugger for message ASCII frames
-          let str = "";
-          for (let i = 0; i < retval.serial.length; i++) {
-            str += String.fromCharCode(retval.serial[i]);
-          }
-
-          resolve({ id: retval.id });
-        })
+        .write(new Uint8Array(serial))
+        .then(() => resolve({ id }))
         .catch((e) => reject(e));
     });
   }
 
-  public async sendRawToTransport(data: Uint8Array): Promise<void> {
-    while (this._transport.isWriteLocked()) {
-      await this.sleep(1);
-    }
-    debug_lowlevel_store.push_outbound(Array.from(data));
-    await this._transport.write(data);
+  public sendRawDataToGrid(
+    data: Uint8Array,
+    options?: {
+      responseRequired?: boolean;
+      filter?: any;
+      responseTimeout?: number;
+    },
+  ): Promise<any> {
+    const bufferElement: BufferElement = {
+      id: 0,
+      virtual: false,
+      rawBytes: data,
+      descr: {
+        brc_parameters: { DX: -1, DY: -1 },
+        class_name: InstructionClassName.IMMEDIATE,
+        class_instr: InstructionClass.EXECUTE,
+        class_parameters: {},
+      },
+      responseRequired: options?.responseRequired,
+      filter: options?.filter,
+      responseTimeout: options?.responseTimeout,
+    };
+    return this.add_last(bufferElement);
   }
 
   public async waitResponseFromGrid(
@@ -287,7 +302,7 @@ export class WriteBuffer implements Readable<WriteBufferData> {
     sendImmediate: boolean = false,
   ) {
     return new Promise((resolve, reject) => {
-      this.sendDataToGrid(bufferElement.descr)
+      this.sendDataToGrid(bufferElement.descr, bufferElement.rawBytes)
         .then(async (result) => {
           const { id } = result;
           if (bufferElement.responseRequired === true && !sendImmediate) {

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -86,7 +86,7 @@ export type BufferElement = {
   };
 };
 
-enum ResponseStatus {
+export enum ResponseStatus {
   OK = 0,
   TIMEOUT = 1,
   ERROR = 2,

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -13,6 +13,7 @@ import { ConnectionSimulator } from "./connection-simulator";
 import { MessageStream } from "../serialport/message-stream.store";
 import { logger } from "./runtime.store";
 import { debug_lowlevel_store } from "../main/panels/DebugMonitor/DebugMonitor.store";
+import { runtime_manager } from "./runtime-manager.store";
 
 export enum InstructionClassName {
   HEARTBEAT = "HEARTBEAT",
@@ -261,6 +262,8 @@ export class WriteBuffer implements Readable<WriteBufferData> {
   public sendRawDataToGrid(
     data: Uint8Array,
     options?: {
+      dx?: number;
+      dy?: number;
       responseRequired?: boolean;
       filter?: any;
       responseTimeout?: number;
@@ -271,7 +274,7 @@ export class WriteBuffer implements Readable<WriteBufferData> {
       virtual: false,
       rawBytes: data,
       descr: {
-        brc_parameters: { DX: -1, DY: -1 },
+        brc_parameters: { DX: options?.dx ?? -127, DY: options?.dy ?? -127 },
         class_name: InstructionClassName.IMMEDIATE,
         class_instr: InstructionClass.EXECUTE,
         class_parameters: {},
@@ -408,6 +411,15 @@ export class WriteBuffer implements Readable<WriteBufferData> {
   public validateBufferElement(obj: BufferElement) {
     if (obj.responseRequired && obj.sendImmediate) {
       throw "Response required and send immediate can not be used together!";
+    }
+    const { DX, DY } = obj.descr.brc_parameters;
+    const modules = get(runtime_manager).active?.runtime?.modules ?? [];
+    const available =
+      DX === -127 && DY === -127
+        ? modules.length > 0
+        : modules.some((m) => m.dx === DX && m.dy === DY);
+    if (!available) {
+      throw `Module [${DX}, ${DY}] is not connected`;
     }
   }
 

--- a/src/renderer/serialport/evaluate-parser.ts
+++ b/src/renderer/serialport/evaluate-parser.ts
@@ -31,7 +31,7 @@ function readStr(raw: number[], pos: number, length: number): string {
 // Decode the \xNN escape sequences the firmware uses for non-printable chars
 function decodeString(s: string): string {
   return s.replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) =>
-    String.fromCharCode(parseInt(hex, 16))
+    String.fromCharCode(parseInt(hex, 16)),
   );
 }
 
@@ -40,7 +40,7 @@ function decodeString(s: string): string {
 function parseElements(
   raw: number[],
   pos: number,
-  count: number
+  count: number,
 ): [LuaValue[], number] {
   const results: LuaValue[] = [];
 

--- a/src/renderer/serialport/evaluate-parser.ts
+++ b/src/renderer/serialport/evaluate-parser.ts
@@ -1,0 +1,99 @@
+import { writable } from "svelte/store";
+
+// Lua type constants (from Lua's lobject.h)
+const LUA_TNIL = 0;
+const LUA_TBOOLEAN = 1;
+const LUA_TNUMBER = 3;
+const LUA_TSTRING = 4;
+const LUA_TTABLE = 5;
+
+export type LuaValue = null | boolean | number | string | LuaTable;
+export type LuaTable = { [key: string | number]: LuaValue };
+
+// Read `length` ASCII chars from raw starting at pos and parse as hex integer
+function readHex(raw: number[], pos: number, length: number): number {
+  let str = "";
+  for (let i = 0; i < length; i++) {
+    str += String.fromCharCode(raw[pos + i]);
+  }
+  return parseInt(str, 16);
+}
+
+// Read `length` ASCII chars from raw starting at pos as a plain string
+function readStr(raw: number[], pos: number, length: number): string {
+  let str = "";
+  for (let i = 0; i < length; i++) {
+    str += String.fromCharCode(raw[pos + i]);
+  }
+  return str;
+}
+
+// Decode the \xNN escape sequences the firmware uses for non-printable chars
+function decodeString(s: string): string {
+  return s.replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+}
+
+// Parse `count` Lua values from raw[] starting at pos.
+// Returns the decoded values and the new position in raw[].
+function parseElements(
+  raw: number[],
+  pos: number,
+  count: number
+): [LuaValue[], number] {
+  const results: LuaValue[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const type = readHex(raw, pos, 2);
+    pos += 2;
+
+    if (type === LUA_TNIL) {
+      results.push(null);
+      continue; // nil has no SIZE or DATA
+    }
+
+    const size = readHex(raw, pos, 4);
+    pos += 4;
+
+    switch (type) {
+      case LUA_TBOOLEAN: {
+        results.push(readStr(raw, pos, size) === "ff");
+        pos += size;
+        break;
+      }
+      case LUA_TNUMBER: {
+        // Integers are formatted as "%lld", floats as "%.7f"
+        results.push(Number(readStr(raw, pos, size)));
+        pos += size;
+        break;
+      }
+      case LUA_TSTRING: {
+        results.push(decodeString(readStr(raw, pos, size)));
+        pos += size;
+        break;
+      }
+      case LUA_TTABLE: {
+        // size = number of key-value pairs; read size*2 elements recursively
+        const [pairs, newPos] = parseElements(raw, pos, size * 2);
+        const table: LuaTable = {};
+        for (let j = 0; j < pairs.length; j += 2) {
+          table[pairs[j] as string | number] = pairs[j + 1];
+        }
+        results.push(table);
+        pos = newPos;
+        break;
+      }
+    }
+  }
+
+  return [results, pos];
+}
+
+// Entry point: parse the variable-length element payload from an EVALUATE response.
+// raw[6..7] = ELEMENTS count (2 hex chars), raw[8+] = element data.
+export function parseEvaluateResponse(class_descr: any): LuaValue[] {
+  const count = readHex(class_descr.raw, 6, 2);
+  const [values] = parseElements(class_descr.raw, 8, count);
+  return values;
+}

--- a/src/renderer/serialport/message-stream.store.ts
+++ b/src/renderer/serialport/message-stream.store.ts
@@ -16,6 +16,7 @@ import { user_input } from "../runtime/user-input.store";
 import { runtime_manager } from "../runtime/runtime-manager.store.js";
 import { Runtime } from "../runtime/string-table.js";
 import { EventType, EventTypeToNumber } from "@intechstudio/grid-protocol";
+import { parseEvaluateResponse } from "./evaluate-parser";
 
 export const incoming_messages = writable([]);
 export function add_datapoint(key, value) {
@@ -332,6 +333,10 @@ export class MessageStream {
         ];
         const device = this.runtime.findModule(sx, sy);
         midi_stream.update(class_descr, device);
+      }
+
+      if (class_descr.class_name === "EVALUATE") {
+        console.log("[EVALUATE]", parseEvaluateResponse(class_descr));
       }
 
       if (class_descr.class_name === "CONFIG") {

--- a/src/renderer/serialport/message-stream.store.ts
+++ b/src/renderer/serialport/message-stream.store.ts
@@ -16,7 +16,6 @@ import { user_input } from "../runtime/user-input.store";
 import { runtime_manager } from "../runtime/runtime-manager.store.js";
 import { Runtime } from "../runtime/string-table.js";
 import { EventType, EventTypeToNumber } from "@intechstudio/grid-protocol";
-import { parseEvaluateResponse } from "./evaluate-parser";
 
 export const incoming_messages = writable([]);
 export function add_datapoint(key, value) {
@@ -333,10 +332,6 @@ export class MessageStream {
         ];
         const device = this.runtime.findModule(sx, sy);
         midi_stream.update(class_descr, device);
-      }
-
-      if (class_descr.class_name === "EVALUATE") {
-        console.log("[EVALUATE]", parseEvaluateResponse(class_descr));
       }
 
       if (class_descr.class_name === "CONFIG") {


### PR DESCRIPTION
## Firmware
Must use Nightly Firmware

## Summary

- New **Evaluate** tab in the Debug Monitor panel: Monaco editor for Lua code, sends a Grid `EVALUATE` frame and displays the typed response (ACK/NACK, message ID, decoded Lua return values)
- New `evaluate-parser.ts`: decodes EVALUATE response elements — nil, boolean, number, string, and nested tables
- New `SendRaw` component extracted from `SendImmediate` into its own panel
- `sendRawDataToGrid()` added to `WriteBuffer` — queues pre-encoded raw bytes through the engine FIFO with full `responseRequired` / `filter` / `responseTimeout` support; replaces the old `sendRawToTransport()` bypass
- Evaluate is now the default selected panel; module selector lifted to `DebugMonitor` parent and shared across all send panels

## Test plan

- [x] Connect a Grid module and open the Debug Monitor
- [x] Select a specific module from the dropdown (or leave as Global)
- [x] In the **Evaluate** tab, enter `return 1, "hello", true` and click Send — verify ACK status, message ID, and decoded values appear
- [x] Enter `return nil` — verify `[null]` is returned
- [x] Enter a table: `return {a=1, b=2}` — verify table is decoded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)