### PR TITLE
Speed up both web and electron app startup

### DIFF
--- a/src/renderer/lib/monaco.ts
+++ b/src/renderer/lib/monaco.ts
@@ -5,7 +5,7 @@ import {
   editor as monaco_editor,
   languages as monaco_languages,
   Position,
-} from "monaco-editor";
+} from "monaco-editor/esm/vs/editor/editor.api.js";
 import { TabFocus } from "monaco-editor/esm/vs/editor/browser/config/tabFocus.js";
 import { ElementType, grid } from "@intechstudio/grid-protocol";
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,6 @@ import * as colors from "tailwindcss/colors";
 
 const config = {
   content: [
-    "./src/**/*.{html,js,svelte,ts}",
     "./node_modules/grid-uikit/src/**/*.{html,js,svelte,ts}",
     "./src/renderer/**/*.{html,js,svelte,ts}",
   ],


### PR DESCRIPTION
- Fixed a regression caused by untargeted tailwind blob parsing. 
- Monaco now only imports the core editor, without the various unused language modules (python, rust, etc...)