### PR TITLE
Suku file manager fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20260506.533",
-        "@intechstudio/grid-uikit": "^1.20260421.817",
+        "@intechstudio/grid-uikit": "^1.20260522.1231",
         "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
         "adm-zip": "^0.5.10",
         "axios": "^1.15.2",
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20260421.817",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20260421.817.tgz",
-      "integrity": "sha512-qbg5S5Z+tSaYpWc6EIjkL3Lt3Kh26M0zs+b2v6uduzym/G38NNOwJXntOFA2+NIrSwDsUciEKExnfXONNEHogA==",
+      "version": "1.20260522.1231",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20260522.1231.tgz",
+      "integrity": "sha512-hXsEeivoSOGwV+RBLCKryd9FOclJMxgTYi9E7f64WsSJkA32l2YkgwU8lG472O6WHZsUUGxWcVcbtgXw7NIpOA==",
       "dependencies": {
         "@melt-ui/svelte": "^0.86.6",
         "color-convert": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20260506.533",
-    "@intechstudio/grid-uikit": "^1.20260421.817",
+    "@intechstudio/grid-uikit": "^1.20260522.1231",
     "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
     "adm-zip": "^0.5.10",
     "axios": "^1.15.2",

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -603,13 +603,13 @@
           <span class="opacity-40">/</span>
         {/if}
         <button
-          class="hover:opacity-100 hover:underline px-0.5 rounded {i ===
+          class="hover:opacity-100 hover:underline px-1 py-0.5 rounded {i ===
           breadcrumbs.length - 1
             ? 'opacity-100'
             : 'opacity-60'}"
           onclick={() => onBreadcrumbClick(i)}
         >
-          {segment}
+          {i === 0 ? "root" : segment}
         </button>
       {/each}
     </div>
@@ -619,7 +619,7 @@
       <div class="flex flex-col gap-1">
         <div class="flex flex-row gap-2">
           <input
-            class="flex-grow bg-transparent border border-white/20 rounded px-2 py-1 font-mono text-sm outline-none focus:border-white/50"
+            class="flex-grow bg-transparent border border-white/20 rounded px-2 py-1 font-mono text-base outline-none focus:border-white/50"
             placeholder={opPlaceholder[activeOp]}
             bind:value={opValue}
             onkeydown={(e) => {
@@ -635,7 +635,7 @@
           <MoltenPushButton click={cancelOp} text="Cancel" />
         </div>
         {#if opError}
-          <p class="text-xs text-red-400">{opError}</p>
+          <p class="text-base text-red-400">{opError}</p>
         {/if}
       </div>
     {:else}
@@ -673,13 +673,13 @@
     <!-- File list -->
     <div class="min-h-0">
       {#if error}
-        <p class="text-sm text-red-400 select-text">{error}</p>
+        <p class="text-base text-red-400 select-text">{error}</p>
       {:else if loading}
-        <p class="text-sm opacity-50">Loading...</p>
+        <p class="text-base opacity-50">Loading...</p>
       {:else if entries.length === 0}
-        <p class="text-sm opacity-50">Empty directory.</p>
+        <p class="text-base opacity-50">Empty directory.</p>
       {:else}
-        <div class="flex flex-col overflow-y-auto gap-0.5 font-mono text-sm">
+        <div class="flex flex-col overflow-y-auto gap-0.5 font-mono text-base">
           {#each entries as entry}
             <button
               class="flex items-center gap-2 px-2 py-1 rounded text-left w-full {selectedEntry ===
@@ -698,7 +698,7 @@
       {/if}
     </div>
   {:else}
-    <p class="text-sm opacity-50">No modules connected.</p>
+    <p class="text-base opacity-50">No modules connected.</p>
   {/if}
 
   <div
@@ -710,11 +710,11 @@
       : ''}"
   >
     <div class="flex items-center gap-2">
-      <p class="text-xs opacity-50 font-mono flex-grow">
+      <p class="text-base opacity-50 font-mono flex-grow">
         {selectedEntry ?? ""}{fileDirty ? " •" : ""}
       </p>
       {#if contentInfo !== null}
-        <span class="text-xs font-mono opacity-50"
+        <span class="text-base font-mono opacity-50"
           >{contentInfo.bytes} B · {contentInfo.chunks} chunks</span
         >
       {/if}
@@ -740,10 +740,10 @@
       />
     </div>
     {#if luaSyntaxError}
-      <p class="text-xs text-red-400 font-mono">{luaSyntaxError}</p>
+      <p class="text-base text-red-400 font-mono">{luaSyntaxError}</p>
     {/if}
     {#if readingFile}
-      <p class="text-sm opacity-50">
+      <p class="text-base opacity-50">
         {downloadProgress
           ? `Reading ${downloadProgress.current}/${downloadProgress.total}`
           : "Reading..."}

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -578,7 +578,7 @@
   });
 </script>
 
-<div class="w-full h-full flex flex-col p-4 gap-2 overflow-hidden">
+<container data-testid="file-manager" class="flex flex-col h-full p-4">
   <!-- Module selector -->
   <div class="flex flex-row gap-2">
     <div class="flex-grow">
@@ -596,7 +596,7 @@
   {#if target}
     <!-- Path breadcrumb -->
     <div
-      class="flex flex-row items-center gap-0.5 font-mono text-xs opacity-70 flex-wrap"
+      class="flex flex-row items-center gap-0.5 font-mono opacity-70 flex-wrap"
     >
       {#each breadcrumbs as segment, i}
         {#if i > 0}
@@ -754,4 +754,4 @@
         : ''}"
     />
   </div>
-</div>
+</container>

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -594,26 +594,6 @@
   </div>
 
   {#if target}
-    <!-- Path breadcrumb -->
-    <div
-      class="flex flex-row items-center gap-0.5 font-mono opacity-70 flex-wrap"
-    >
-      {#each breadcrumbs as segment, i}
-        {#if i > 0}
-          <span class="opacity-40">/</span>
-        {/if}
-        <button
-          class="hover:opacity-100 hover:underline px-1 py-0.5 rounded {i ===
-          breadcrumbs.length - 1
-            ? 'opacity-100'
-            : 'opacity-60'}"
-          onclick={() => onBreadcrumbClick(i)}
-        >
-          {i === 0 ? "root" : segment}
-        </button>
-      {/each}
-    </div>
-
     <!-- Operations row -->
     {#if activeOp}
       <div class="flex flex-col gap-1">
@@ -669,6 +649,26 @@
         />
       </div>
     {/if}
+
+    <!-- Path breadcrumb -->
+    <div
+      class="flex flex-row items-center gap-0.5 font-mono opacity-70 flex-wrap"
+    >
+      {#each breadcrumbs as segment, i}
+        {#if i > 0}
+          <span class="opacity-40">/</span>
+        {/if}
+        <button
+          class="hover:opacity-100 hover:underline px-1 py-0.5 rounded {i ===
+          breadcrumbs.length - 1
+            ? 'opacity-100'
+            : 'opacity-60'}"
+          onclick={() => onBreadcrumbClick(i)}
+        >
+          {i === 0 ? "root" : segment}
+        </button>
+      {/each}
+    </div>
 
     <!-- File list -->
     <div class="min-h-0">

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -671,36 +671,38 @@
     {/if}
 
     <!-- File list -->
-    {#if error}
-      <p class="text-sm text-red-400 select-text">{error}</p>
-    {:else if loading}
-      <p class="text-sm opacity-50">Loading...</p>
-    {:else if entries.length === 0}
-      <p class="text-sm opacity-50">Empty directory.</p>
-    {:else}
-      <div class="flex flex-col overflow-y-auto gap-0.5 font-mono text-sm">
-        {#each entries as entry}
-          <button
-            class="flex items-center gap-2 px-2 py-1 rounded text-left w-full {selectedEntry ===
-            entry.name
-              ? 'bg-white/20'
-              : 'hover:bg-white/10'}"
-            onclick={() => onEntryClick(entry)}
-          >
-            <span class="opacity-50 shrink-0"
-              >{entry.type === "dir" ? "📁" : "📄"}</span
+    <div class="min-h-0">
+      {#if error}
+        <p class="text-sm text-red-400 select-text">{error}</p>
+      {:else if loading}
+        <p class="text-sm opacity-50">Loading...</p>
+      {:else if entries.length === 0}
+        <p class="text-sm opacity-50">Empty directory.</p>
+      {:else}
+        <div class="flex flex-col overflow-y-auto gap-0.5 font-mono text-sm">
+          {#each entries as entry}
+            <button
+              class="flex items-center gap-2 px-2 py-1 rounded text-left w-full {selectedEntry ===
+              entry.name
+                ? 'bg-white/20'
+                : 'hover:bg-white/10'}"
+              onclick={() => onEntryClick(entry)}
             >
-            <span class="truncate">{entry.name}</span>
-          </button>
-        {/each}
-      </div>
-    {/if}
+              <span class="opacity-50 shrink-0"
+                >{entry.type === "dir" ? "📁" : "📄"}</span
+              >
+              <span class="truncate">{entry.name}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
   {:else}
     <p class="text-sm opacity-50">No modules connected.</p>
   {/if}
 
   <div
-    class="border-t border-white/10 pt-2 flex flex-col gap-1 {(fileContent ===
+    class="border-t border-white/10 pt-2 flex flex-col gap-1 flex-grow min-h-0 {(fileContent ===
       null &&
       !readingFile) ||
     entries.find((e) => e.name === selectedEntry)?.type === 'dir'
@@ -749,7 +751,7 @@
     {/if}
     <div
       bind:this={monacoElement}
-      class="w-full h-48 border border-white/20 rounded {readingFile
+      class="w-full flex-grow min-h-0 border border-white/20 rounded {readingFile
         ? 'hidden'
         : ''}"
     />


### PR DESCRIPTION
- Fixed z-index issue: Removed z-index: 1 from .button-container in grid-uikit/src/lib/MoltenPushButton.svelte — buttons were rendering above sidebar tooltips. Rebuilt the uikit dist.
- Updated uikit dependency: Upgraded @intechstudio/grid-uikit from 1.20260421.817 to 1.20260522.1231 (latest on npm, which already includes the fix).
- Root element: Changed <div> → <container data-testid="file-manager"> to match the pattern used by other panels (e.g. MidiMonitor).
- Removed overflow-hidden from root element — was creating a stacking context that blocked tooltips.
- Editor height: Changed from fixed h-48 to flex-grow min-h-0 so it fills remaining vertical space, with the file list taking natural size above it.
- Font sizes: Replaced all text-xs and text-sm with text-base for default sizing.
- Breadcrumb padding: Added px-1 py-0.5 to breadcrumb buttons.
- Breadcrumb display: First segment now shows "root" instead of "/", 