### PR TITLE
fix: detect missing Web Serial API by feature check instead of browser sniff

### DIFF
--- a/src/renderer/preload-window-config.ts
+++ b/src/renderer/preload-window-config.ts
@@ -28,8 +28,8 @@ declare global {
 }
 
 if (import.meta.env.VITE_BUILD_TARGET == "web") {
-  // handle non-chromium based browsers
-  if (window.chrome == null) {
+  // mock Web Serial API if not available (e.g. Firefox)
+  if (!("serial" in navigator)) {
     navigator.serial = {
       addEventListener: () => {},
     };

--- a/src/renderer/preload-window-config.ts
+++ b/src/renderer/preload-window-config.ts
@@ -27,7 +27,7 @@ declare global {
   }
 }
 
-if (import.meta.env.VITE_BUILD_TARGET == "web") {
+if (import.meta.env.VITE_BUILD_TARGET == "web" || typeof window.ctxProcess === "undefined") {
   // mock Web Serial API if not available (e.g. Firefox)
   if (!("serial" in navigator)) {
     navigator.serial = {

--- a/src/renderer/serialport/serialport.ts
+++ b/src/renderer/serialport/serialport.ts
@@ -18,39 +18,40 @@ import { appSettings } from "../runtime/app-helper.store.js";
 import { type GridTransport } from "./transport.js";
 import { SerialTransport } from "./serial-transport.js";
 
-const configuration = window.ctxProcess.configuration();
-
 interface SerialPortFilter {
   usbVendorId?: number;
   usbProductId?: number;
 }
 
-const filter: SerialPortFilter[] = [
-  {
-    usbVendorId: parseInt(configuration.USB_VID_0),
-    usbProductId: parseInt(configuration.USB_PID_0),
-  },
-  {
-    usbVendorId: parseInt(configuration.USB_VID_1),
-    usbProductId: parseInt(configuration.USB_PID_1),
-  },
-  {
-    usbVendorId: parseInt(configuration.USB_VID_2),
-    usbProductId: parseInt(configuration.USB_PID_2),
-  },
-  {
-    usbVendorId: parseInt(configuration.BOOTLOADER_GRID_D51_VID),
-    usbProductId: parseInt(configuration.BOOTLOADER_GRID_D51_PID),
-  },
-  {
-    usbVendorId: parseInt(configuration.BOOTLOADER_GRID_ESP32_VID),
-    usbProductId: parseInt(configuration.BOOTLOADER_GRID_ESP32_PID),
-  },
-  {
-    usbVendorId: parseInt(configuration.BOOTLOADER_KNOT_VID),
-    usbProductId: parseInt(configuration.BOOTLOADER_KNOT_PID),
-  },
-];
+function getSerialFilter(): SerialPortFilter[] {
+  const configuration = window.ctxProcess.configuration();
+  return [
+    {
+      usbVendorId: parseInt(configuration.USB_VID_0),
+      usbProductId: parseInt(configuration.USB_PID_0),
+    },
+    {
+      usbVendorId: parseInt(configuration.USB_VID_1),
+      usbProductId: parseInt(configuration.USB_PID_1),
+    },
+    {
+      usbVendorId: parseInt(configuration.USB_VID_2),
+      usbProductId: parseInt(configuration.USB_PID_2),
+    },
+    {
+      usbVendorId: parseInt(configuration.BOOTLOADER_GRID_D51_VID),
+      usbProductId: parseInt(configuration.BOOTLOADER_GRID_D51_PID),
+    },
+    {
+      usbVendorId: parseInt(configuration.BOOTLOADER_GRID_ESP32_VID),
+      usbProductId: parseInt(configuration.BOOTLOADER_GRID_ESP32_PID),
+    },
+    {
+      usbVendorId: parseInt(configuration.BOOTLOADER_KNOT_VID),
+      usbProductId: parseInt(configuration.BOOTLOADER_KNOT_PID),
+    },
+  ];
+}
 
 export type GridConnection = {
   id: string;
@@ -194,6 +195,7 @@ export class GridConnectionManager implements Readable<GridConnection[]> {
 
   static async tryConnectSerial() {
     try {
+      const filter = getSerialFilter();
       let ports: any[];
       if (import.meta.env.VITE_BUILD_TARGET == "web") {
         const port = await navigator.serial.requestPort({ filters: filter });


### PR DESCRIPTION
## Summary
- Firefox 109+ added `window.chrome` for compatibility, breaking the `window.chrome == null` check that was used to inject the `navigator.serial` mock in web mode
- The hosted app stopped loading on Firefox because `navigator.serial` was undefined at startup
- Switch to `!('serial' in navigator)` — a direct feature check that works correctly across all browsers

## Test plan
- [ ] Verify the hosted web app loads on Firefox without errors
- [ ] Verify Web Serial connect still works on Chrome/Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)