### PR TITLE
fix: correct variable shadowing and NaN step in ButtonStepFace

### DIFF
--- a/src/renderer/config-blocks/headers/ButtonStepFace.svelte
+++ b/src/renderer/config-blocks/headers/ButtonStepFace.svelte
@@ -24,26 +24,25 @@
   function handleEventDataChange(event: EventData) {
     step = 0;
     let stack = [];
-    for (const action of event.config) {
-      if (action.short === "bst0") {
+    for (const a of event.config) {
+      if (a.short === "bst0") {
         stack.push(0);
       }
 
-      if (action.short === "bste") {
+      if (a.short === "bste") {
         stack.pop();
       }
 
-      if (action.short === "bstn") {
+      if (a.short === "bstn") {
+        if (stack.length === 0) continue;
         step = ++stack[stack.length - 1];
-        if (action.id === action.id) {
-          const defaultScript = action.information.defaultLua;
+        if (a.id === action.id) {
+          const defaultScript = a.information.defaultLua;
           const newScript = defaultScript.replace("N", String(step));
-          const oldScript = action.script;
+          const oldScript = a.script;
           if (newScript !== oldScript) {
-            action.updateData(
-              new ActionData(action.short, newScript, action.name),
-            );
-            action.sendToGrid();
+            a.updateData(new ActionData(a.short, newScript, a.name));
+            a.sendToGrid();
           }
           return;
         }

--- a/src/renderer/main/ErrorConsole.svelte
+++ b/src/renderer/main/ErrorConsole.svelte
@@ -236,7 +236,7 @@
               ? 'bg-gray-800'
               : 'bg-gray-900'} justify-center flex flex-row items-center h-16"
           >
-            <div>{log.reason}</div>
+            <div class="select-text">{log.reason}</div>
             {#if log.solution !== undefined}
               <div class="ml-4 font-bold">{log.solution.message}</div>
 
@@ -279,7 +279,7 @@
       in:fly|global={{ x: -50, delay: 0, duration: 500 }}
       class="w-full {notification.class
         ? notification.class
-        : 'bg-green-500'} justify-center flex flex-row items-center h-16"
+        : 'bg-green-500'} justify-center flex flex-row items-center h-16 select-text"
     >
       <div>{notification.message}</div>
 


### PR DESCRIPTION
## Summary
- Loop variable `action` in `handleEventDataChange` shadowed the outer `action` prop, making `action.id === action.id` always `true` — updating the first `bstn` found in config instead of this component's specific action
- During a drag, `bst0` is removed before `bstn`, leaving an empty stack, so `++stack[-1]` produced `NaN`, corrupting the step script to `"elseif self:bstp() == NaN then"` and causing `sendToGrid` to throw with invalid Lua
- Press/Release was unaffected because its middle parts are not selectable and its step numbering is static

## Test plan
- [x] Add a Button Step block with multiple Additional Steps and drag it to a different position — should reorder without errors
- [x] Verify step numbers (Step One, Step Two, etc.) are correct after drag
- [x] Verify Press/Release drag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)