### PR TITLE
SUKU: RxMode config block + validator feedback improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20260520.959",
-        "@intechstudio/grid-uikit": "^1.20260522.1231",
+        "@intechstudio/grid-uikit": "^1.20260609.1254",
         "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
         "adm-zip": "^0.5.10",
         "axios": "^1.16.0",
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/@intechstudio/grid-uikit": {
-      "version": "1.20260522.1231",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20260522.1231.tgz",
-      "integrity": "sha512-hXsEeivoSOGwV+RBLCKryd9FOclJMxgTYi9E7f64WsSJkA32l2YkgwU8lG472O6WHZsUUGxWcVcbtgXw7NIpOA==",
+      "version": "1.20260609.1254",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-uikit/-/grid-uikit-1.20260609.1254.tgz",
+      "integrity": "sha512-uGE2y10OJNLE4o9l47/QP+HwMBSQTNGbzS36uTo7BsD3jv0OBMvZyzBmroghU9bopw5Toy1oLIlxNp2sJuJitw==",
       "dependencies": {
         "@melt-ui/svelte": "^0.86.6",
         "color-convert": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@intechstudio/grid-protocol": "1.20260520.959",
-    "@intechstudio/grid-uikit": "^1.20260522.1231",
+    "@intechstudio/grid-uikit": "^1.20260609.1254",
     "@intechstudio/profile-cloud-webcomponent": "1.20251107.1414",
     "adm-zip": "^0.5.10",
     "axios": "^1.16.0",

--- a/src/renderer/config-blocks/GamePadButton.svelte
+++ b/src/renderer/config-blocks/GamePadButton.svelte
@@ -98,7 +98,9 @@
 
   function sendData(value, index) {
     scriptSegments[index] = value;
-
+    validators.forEach((v, i) => {
+      v.value = v.func(scriptSegments[i] ?? "");
+    });
     const script = Script.toScript({
       short: action.short,
       array: scriptSegments,

--- a/src/renderer/config-blocks/LedAnimationStart.svelte
+++ b/src/renderer/config-blocks/LedAnimationStart.svelte
@@ -120,7 +120,9 @@
 
   function sendData(e, index) {
     scriptSegments[index] = e;
-    // important to set the function name = human readable for now
+    validators.forEach((v, i) => {
+      v.value = v.func(scriptSegments[i] ?? "");
+    });
     const script = Script.toScript({
       short: "glpfs",
       array: scriptSegments,
@@ -223,7 +225,7 @@
         on:input={(e) => {
           const { value, validationError } = e.detail;
           script = value;
-          validators[i].value = !validationError;
+          validators[i + 2].value = !validationError;
           sendData(value, i + 2);
         }}
         on:change={() => dispatch("sync")}

--- a/src/renderer/config-blocks/LedAnimationStop.svelte
+++ b/src/renderer/config-blocks/LedAnimationStop.svelte
@@ -120,7 +120,9 @@
 
   function sendData(e, index) {
     scriptSegments[index] = e;
-    // important to set the function name = human readable for now
+    validators.forEach((v, i) => {
+      v.value = v.func(scriptSegments[i] ?? "");
+    });
     const script = Script.toScript({
       short: "glpfs",
       array: scriptSegments,

--- a/src/renderer/config-blocks/RxMode.svelte
+++ b/src/renderer/config-blocks/RxMode.svelte
@@ -1,0 +1,217 @@
+<script lang="ts" context="module">
+  import type { ActionBlockInformation } from "./ActionBlockInformation.ts";
+  import RegularActionBlockFace from "./headers/RegularActionBlockFace.svelte";
+  export const header = RegularActionBlockFace;
+
+  export const information: ActionBlockInformation = {
+    short: "rxmd",
+    name: "RxMode",
+    rendering: "standard",
+    category: "function",
+    displayName: "RX Mode",
+    color: "#4A6FA5",
+    defaultLua: "grxm(0,3) grxm(1,3) grxm(2,0) grxm(3,0)",
+    icon: `<span class="block w-full text-center font-gt-pressura text-sm font-bold">RX</span>`,
+    blockIcon: `<span class="block w-full text-center font-gt-pressura text-sm font-bold">RX</span>`,
+    selectable: true,
+    hiddenInMinimalist: true,
+    movable: true,
+    hideIcon: false,
+    type: "single",
+    toggleable: true,
+    editName: true,
+    version: "2.0",
+  };
+</script>
+
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { MeltCheckbox, MeltSelect } from "@intechstudio/grid-uikit";
+  import { GridAction, ActionData } from "./../runtime/runtime";
+  import SendFeedback from "../main/user-interface/SendFeedback.svelte";
+  import { tooltip } from "../main/_actions/tooltip.ts";
+
+  export let action: GridAction;
+  const dispatch = createEventDispatcher();
+
+  const typeLabels = [
+    {
+      label: "MIDI Voice",
+      tooltip:
+        "Note On/Off, Control Change, Pitch Bend and other standard MIDI voice messages",
+    },
+    { label: "MIDI Sysex", tooltip: "System Exclusive messages" },
+    {
+      label: "MIDI RTM",
+      tooltip: "Real Time Messages: MIDI clock, start, stop, continue",
+    },
+    { label: "Event View", tooltip: "Grid internal event view messages" },
+  ];
+
+  const presetConfigs: Record<string, number[]> = {
+    default: [3, 3, 0, 0],
+    default_vsn1: [3, 3, 0, 6],
+    midi_sync: [3, 3, 3, 6],
+  };
+
+  const presetOptions = [
+    { title: "Default", value: "default" },
+    { title: "Default (VSN1)", value: "default_vsn1" },
+    { title: "MIDI Sync", value: "midi_sync" },
+    { title: "Custom", value: "custom" },
+  ];
+
+  let selectedPreset = "custom";
+
+  let rxConfig: { forward: boolean; external: boolean; internal: boolean }[] = [
+    { forward: false, external: false, internal: false },
+    { forward: false, external: false, internal: false },
+    { forward: false, external: false, internal: false },
+    { forward: false, external: false, internal: false },
+  ];
+
+  $: if (!$action.invalid) {
+    parseScript($action);
+  }
+
+  // Apply preset when selectedPreset changes from the dropdown
+  $: if (selectedPreset !== "custom") {
+    const modes = presetConfigs[selectedPreset];
+    if (modes) {
+      const current = rxConfig.map(
+        (c) =>
+          (c.forward ? 1 : 0) | (c.external ? 2 : 0) | (c.internal ? 4 : 0),
+      );
+      if (!modes.every((m, i) => m === current[i])) {
+        rxConfig = modes.map((m) => ({
+          forward: (m & 0x01) !== 0,
+          external: (m & 0x02) !== 0,
+          internal: (m & 0x04) !== 0,
+        }));
+        sendData();
+        dispatch("sync");
+      }
+    }
+  }
+
+  function syncPresetSelection() {
+    const modes = rxConfig.map(
+      (c) => (c.forward ? 1 : 0) | (c.external ? 2 : 0) | (c.internal ? 4 : 0),
+    );
+    const match = (Object.entries(presetConfigs) as [string, number[]][]).find(
+      ([, vals]) => vals.every((v, i) => v === modes[i]),
+    );
+    selectedPreset = match ? match[0] : "custom";
+  }
+
+  function parseScript(data: ActionData) {
+    const newConfig = [
+      { forward: false, external: false, internal: false },
+      { forward: false, external: false, internal: false },
+      { forward: false, external: false, internal: false },
+      { forward: false, external: false, internal: false },
+    ];
+
+    const regex = /grxm\((\d+),(\d+)\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(data.script)) !== null) {
+      const type = parseInt(match[1]);
+      const mode = parseInt(match[2]);
+      if (type >= 0 && type <= 3) {
+        newConfig[type].forward = (mode & 0x01) !== 0;
+        newConfig[type].external = (mode & 0x02) !== 0;
+        newConfig[type].internal = (mode & 0x04) !== 0;
+      }
+    }
+    rxConfig = newConfig;
+    syncPresetSelection();
+  }
+
+  function buildScript(): string {
+    const calls: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const c = rxConfig[i];
+      const mode =
+        (c.forward ? 0x01 : 0) |
+        (c.external ? 0x02 : 0) |
+        (c.internal ? 0x04 : 0);
+      calls.push(`grxm(${i},${mode})`);
+    }
+    return calls.join(" ");
+  }
+
+  function sendData() {
+    dispatch("update-action", {
+      short: action.short,
+      script: buildScript(),
+      validationError: false,
+    });
+  }
+
+  function handleChange() {
+    sendData();
+    dispatch("sync");
+    syncPresetSelection();
+  }
+</script>
+
+<action-rx-mode class="flex flex-col w-full p-2 pointer-events-auto gap-2">
+  <div class="px-2">
+    <MeltSelect
+      options={presetOptions}
+      bind:target={selectedPreset}
+      size="full"
+      title="Preset"
+    />
+  </div>
+  <div class="flex flex-col gap-1 px-2">
+    <div class="flex items-center font-semibold text-gray-400">
+      <div class="flex-1">Type</div>
+      <div
+        class="w-14 shrink-0 text-center"
+        use:tooltip={{ text: "Forward from USB" }}
+      >
+        USB
+      </div>
+      <div
+        class="w-14 shrink-0 text-center"
+        use:tooltip={{ text: "Handle External" }}
+      >
+        Ext
+      </div>
+      <div
+        class="w-14 shrink-0 text-center"
+        use:tooltip={{ text: "Handle Internal" }}
+      >
+        Int
+      </div>
+    </div>
+    {#each typeLabels as { label, tooltip: tip }, i}
+      <div class="flex items-center">
+        <div class="flex-1" use:tooltip={{ text: tip }}>{label}</div>
+        <div class="w-14 shrink-0 flex justify-center">
+          <MeltCheckbox
+            style="transparent"
+            bind:target={rxConfig[i].forward}
+            on:change={handleChange}
+          />
+        </div>
+        <div class="w-14 shrink-0 flex justify-center">
+          <MeltCheckbox
+            style="transparent"
+            bind:target={rxConfig[i].external}
+            on:change={handleChange}
+          />
+        </div>
+        <div class="w-14 shrink-0 flex justify-center">
+          <MeltCheckbox
+            style="transparent"
+            bind:target={rxConfig[i].internal}
+            on:change={handleChange}
+          />
+        </div>
+      </div>
+    {/each}
+  </div>
+  <SendFeedback feedback_context="RxMode" />
+</action-rx-mode>

--- a/src/renderer/config-blocks/SettingsButton.svelte
+++ b/src/renderer/config-blocks/SettingsButton.svelte
@@ -100,6 +100,9 @@
   }
 
   function sendData() {
+    validators[0].value = validators[0].func(bmo);
+    validators[1].value = validators[1].func(bmi);
+    validators[2].value = validators[2].func(bma);
     const optional = [];
     optional.push(`self:bmi(${bmi}) self:bma(${bma})`);
 

--- a/src/renderer/config-blocks/SettingsEncoder.svelte
+++ b/src/renderer/config-blocks/SettingsEncoder.svelte
@@ -99,6 +99,11 @@
   }
 
   function sendData() {
+    validators[0].value = validators[0].func(emo);
+    validators[1].value = validators[1].func(ev0);
+    validators[2].value = validators[2].func(emi);
+    validators[3].value = validators[3].func(ema);
+    validators[4].value = validators[4].func(ese);
     const optional = [];
 
     optional.push(`self:emi(${emi}) self:ema(${ema})`);

--- a/src/renderer/config-blocks/SettingsEndless.svelte
+++ b/src/renderer/config-blocks/SettingsEndless.svelte
@@ -103,6 +103,11 @@
   }
 
   function sendData() {
+    validators[0].value = validators[0].func(epmo);
+    validators[1].value = validators[1].func(epv0);
+    validators[2].value = validators[2].func(epmi);
+    validators[3].value = validators[3].func(epma);
+    validators[4].value = validators[4].func(epse);
     const optional = [];
 
     optional.push(`self:epmi(${epmi}) self:epma(${epma})`);

--- a/src/renderer/config-blocks/SettingsPotmeter.svelte
+++ b/src/renderer/config-blocks/SettingsPotmeter.svelte
@@ -82,6 +82,9 @@
   }
 
   function sendData() {
+    validators[0].value = validators[0].func(pmo);
+    validators[1].value = validators[1].func(pmi);
+    validators[2].value = validators[2].func(pma);
     const optional = [];
 
     optional.push(`self:pmi(${pmi})  self:pma(${pma})`);

--- a/src/renderer/config-blocks/TimerSource.svelte
+++ b/src/renderer/config-blocks/TimerSource.svelte
@@ -78,6 +78,9 @@
 
   function sendData(e, index) {
     scriptSegments[index] = e;
+    validators.forEach((v, i) => {
+      v.value = v.func(scriptSegments[i] ?? "");
+    });
     const script = Script.toScript({
       short: action.short,
       array: scriptSegments,

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -25,6 +25,7 @@
   import EditableName from "../../../../config-blocks/components/EditableName.svelte";
   import { selected_actions } from "../../../../runtime/selected-actions.store";
   import { logger } from "../../../../runtime/runtime.store";
+  import { Runtime } from "../../../../runtime/string-table";
   import { get } from "svelte/store";
   import { information } from "../../../../config-blocks/CodeBlock.svelte";
   import { Modal } from "../../../modals/modal.store";
@@ -128,6 +129,12 @@
     toggledBlocks.add(newAction.short);
   }
 
+  function formatBlockMessage(msg: string) {
+    return msg.startsWith("Action block")
+      ? msg.replace("Action block", `${action.information.displayName} block`)
+      : msg;
+  }
+
   function handleUpdateAction(e) {
     const { short, script, validationError } = e.detail;
     const wasInvalid = action.invalid;
@@ -142,7 +149,7 @@
           type: "fail",
           mode: 0,
           classname: "luanotok",
-          message: `${action.information.displayName} action block is not synced due to syntax error`,
+          message: formatBlockMessage(msg),
         });
       }
     });
@@ -150,7 +157,7 @@
       lastErrorMessage = undefined;
       logger.set({
         type: "success",
-        message: `${action.information.displayName} block input is now valid.`,
+        message: formatBlockMessage(Runtime.ErrorText.VALID),
       });
     }
   }

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -38,6 +38,7 @@
 
   let header: typeof SvelteComponent;
   let component: typeof SvelteComponent;
+  let lastErrorMessage: string | undefined;
   let ctrlIsDown = false;
   let toggled = false;
   let isEdit = false;
@@ -129,11 +130,29 @@
 
   function handleUpdateAction(e) {
     const { short, script, validationError } = e.detail;
+    const wasInvalid = action.invalid;
     const oldAction = action;
     const data = new ActionData(short, script, oldAction.name);
     //TODO: Propose better solution
     data.invalid = validationError;
-    updateAction(action, data, false);
+    updateAction(action, data, false, (msg) => {
+      if (msg !== lastErrorMessage) {
+        lastErrorMessage = msg;
+        logger.set({
+          type: "fail",
+          mode: 0,
+          classname: "luanotok",
+          message: `${action.information.displayName} action block is not synced due to syntax error`,
+        });
+      }
+    });
+    if (wasInvalid && !validationError) {
+      lastErrorMessage = undefined;
+      logger.set({
+        type: "success",
+        message: `${action.information.displayName} block input is now valid.`,
+      });
+    }
   }
 
   function handleSendActionToGrid() {

--- a/src/renderer/main/panels/configuration/components/Toolbar.svelte
+++ b/src/renderer/main/panels/configuration/components/Toolbar.svelte
@@ -120,7 +120,15 @@
       <span class="text-sm truncate">
         {#if typeof selectedAction === "undefined" && $appSettings.isMultiView !== true}
           <span style="color: var(--foreground-disabled)">Script length: </span>
-          <span data-testid="charCount"
+          <span
+            data-testid="charCount"
+            class={($event?.toLua().length ?? 0) >=
+            Grid.Protocol.maxScriptLength * 0.98
+              ? "text-error"
+              : ($event?.toLua().length ?? 0) >=
+                  (Grid.Protocol.maxScriptLength / 3) * 2
+                ? "text-yellow-400"
+                : ""}
             >{$event?.toLua().length ?? 0}/{Grid.Protocol.maxScriptLength -
               1}</span
           >

--- a/src/renderer/runtime/operations.ts
+++ b/src/renderer/runtime/operations.ts
@@ -215,10 +215,17 @@ export async function updateAction(
   target: GridAction,
   data: ActionData,
   sync: boolean,
+  onError?: (message: string) => void,
 ) {
   return target
     .updateData(data)
-    .catch(handleError)
+    .catch((e: GridOperationResult) => {
+      if (onError) {
+        onError(e.text);
+      } else {
+        handleError(e);
+      }
+    })
     .finally(() => {
       if (sync) {
         syncWithGrid(target);

--- a/src/renderer/runtime/string-table.ts
+++ b/src/renderer/runtime/string-table.ts
@@ -2,8 +2,9 @@ export namespace Runtime {
   export enum ErrorText {
     LENGTH_ERROR = `Modifications can not be synced with grid, 
         maximum character limit reached. Shorten your code or delete action blocks.`,
-    SYNTAX_ERROR = `Action blocks with syntax error(s) are not synced.`,
-    UNCLOSED_PARENTHESIS = `Action(s) with unclosed parenthesis will not be synced with grid!`,
+    SYNTAX_ERROR = `Action block is not synced due to syntax error`,
+    VALID = `Action block input is now valid.`,
+    UNCLOSED_PARENTHESIS = `Action block is not synced due to unclosed parenthesis`,
     PAGE_CHANGE_DISABLED = `Page change is disabled! Store or discard your unsaved change(s)!`,
     SEND_IMMEDIATE_NO_ACTIVE_MODULE = `Executing LUA failed! No active module is connected!`,
   }


### PR DESCRIPTION
## Summary

- **New block**: Add `RxMode` action block (`src/renderer/config-blocks/RxMode.svelte`)
- **Validator fix**: Re-sync all validator values at the top of `sendData()` in Settings/LED/GamePad/Timer blocks, preventing premature valid-toast when only one of multiple invalid fields clears
- **LedAnimationStart bug fix**: Second group of MeltCombos was updating `validators[i]` instead of `validators[i+2]`, causing fields 2–4 to never mark invalid
- **Deduped error toasts**: `DynamicWrapper` now holds a per-instance `lastErrorMessage` cache via an `onError` callback on `updateAction`, so repeated identical syntax errors don't spam the toast
- **Success toast**: When a block transitions from invalid → valid, a success toast is shown: `"<Block> block input is now valid."`
- **Error toast format**: `"<Block> action block is not synced due to syntax error"`

## Test plan

- [ ] Open a Settings block (Potmeter/Button/Encoder/Endless), enter an invalid value — error toast fires once, not on every keystroke repeat
- [ ] Clear the invalid value — success toast fires
- [ ] Enter invalid value in multiple fields, fix only one — success toast does NOT fire until all fields are valid
- [ ] LedAnimationStart: enter invalid value in fields 3/4/5 — block border turns red and error toast fires
- [ ] Verify RxMode block appears in the action block picker and dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)