### PR TITLE
Add remote debugging port to electron:dev + ignore .playwright-mcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ buildVariables.json
 /blob-report/
 /playwright/.cache/
 screenshot*
+.playwright-mcp/
 src/electron/main.ts
 .vscode/settings.json

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "preinstall": "node ./build-scripts/check-node-version.js",
     "postinstall": "electron-builder install-app-deps",
     "test": "vitest run",
-    "electron:dev": "cross-env NODE_OPTIONS=--max_old_space_size=8198 VITE_BUILD_TARGET=electron VITE_BUILD_ENV=development electron-vite dev --watch",
+    "electron:dev": "cross-env NODE_OPTIONS=--max_old_space_size=8198 VITE_BUILD_TARGET=electron VITE_BUILD_ENV=development electron-vite dev --watch -- --remote-debugging-port=9222",
     "electron-dev": "npm run electron:dev",
     "fix-permissions": "sudo chown root ./node_modules/electron/dist/chrome-sandbox && sudo chmod 4755 ./node_modules/electron/dist/chrome-sandbox",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary

- Adds `-- --remote-debugging-port=9222` to the `electron:dev` script so the electron-devtools MCP (and Chrome DevTools) can connect without passing the flag manually on every launch
- Adds `.playwright-mcp/` to `.gitignore` to exclude the screenshot/snapshot output folder generated by MCP sessions

## Test plan

- [ ] `npm run electron:dev` launches the app and port 9222 is accessible
- [ ] `npm run electron-dev` works identically (it's an alias)
- [ ] `.playwright-mcp/` folder is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)