### PR TITLE
Surface console.error in dev/nightly overlay, show build type, drop alpha builds

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -4,8 +4,6 @@ dotenv.config();
 function productNameByWorkflow() {
   if (process.env.VITE_BUILD_ENV == "nightly") {
     return "grid-editor-nightly";
-  } else if (process.env.VITE_BUILD_ENV == "alpha") {
-    return `grid-editor-alpha-${process.env.RELEASE_VERSION}`;
   } else {
     return "grid-editor";
   }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "e:builder:local": "cross-env VITE_BUILD_ENV=nightly VITE_BUILD_TARGET=electron DEBUG=electron-builder DEBUG=electron-notarize* electron-builder --config electron-builder-config.js --publish never",
     "export": "cross-env VITE_BUILD_ENV=production run-s s:build e:builder",
     "export:nightly": "run-s s:build e:builder:nightly",
-    "export:alpha": "cross-env VITE_BUILD_ENV=alpha run-s s:build e:builder",
     "export:local": "run-s clean-up s:build e:builder:local",
     "clean-up": "rm -rf dist && rm -rf dist-web && rm -rf build",
     "rebuild": "./node_modules/.bin/electron-rebuild.cmd",

--- a/src/renderer/main/ErrorConsole.svelte
+++ b/src/renderer/main/ErrorConsole.svelte
@@ -99,6 +99,22 @@
   onMount(async () => {
     // check for errors
 
+    const originalConsoleError = console.error;
+    console.error = function (...args) {
+      originalConsoleError.apply(console, args);
+      const error = args.find((a) => a instanceof Error);
+      const message = args
+        .map((a) =>
+          a instanceof Error
+            ? a.message
+            : typeof a === "object"
+              ? JSON.stringify(a)
+              : String(a),
+        )
+        .join(" ");
+      displayError(message, error?.stack);
+    };
+
     window.onerror = function myErrorHandler(errorMsg, url, lineNumber) {
       // Supress unhandled but not harmful errors
       if (errorMsg.startsWith("ResizeObserver loop completed")) {

--- a/src/renderer/main/ErrorConsole.svelte
+++ b/src/renderer/main/ErrorConsole.svelte
@@ -99,21 +99,26 @@
   onMount(async () => {
     // check for errors
 
-    const originalConsoleError = console.error;
-    console.error = function (...args) {
-      originalConsoleError.apply(console, args);
-      const error = args.find((a) => a instanceof Error);
-      const message = args
-        .map((a) =>
-          a instanceof Error
-            ? a.message
-            : typeof a === "object"
-              ? JSON.stringify(a)
-              : String(a),
-        )
-        .join(" ");
-      displayError(message, error?.stack);
-    };
+    // Only mirror console.error into the overlay on development/nightly builds,
+    // keeping stable releases quiet for end users.
+    const buildEnv = import.meta.env.VITE_BUILD_ENV;
+    if (buildEnv === "development" || buildEnv === "nightly") {
+      const originalConsoleError = console.error;
+      console.error = function (...args) {
+        originalConsoleError.apply(console, args);
+        const error = args.find((a) => a instanceof Error);
+        const message = args
+          .map((a) =>
+            a instanceof Error
+              ? a.message
+              : typeof a === "object"
+                ? JSON.stringify(a)
+                : String(a),
+          )
+          .join(" ");
+        displayError(message, error?.stack);
+      };
+    }
 
     window.onerror = function myErrorHandler(errorMsg, url, lineNumber) {
       // Supress unhandled but not harmful errors

--- a/src/renderer/main/modals/Welcome.svelte
+++ b/src/renderer/main/modals/Welcome.svelte
@@ -48,7 +48,15 @@
 <MoltenModal {data}>
   <div slot="content">
     <div class="flex-col w-full flex justify-between items-center mb-6">
-      <div class="flex w-full text-4xl opacity-90">Grid Editor {version}</div>
+      <div class="flex w-full text-4xl opacity-90">
+        Grid Editor {version}
+        {#if import.meta.env.VITE_BUILD_ENV == "nightly"}
+          {import.meta.env.VITE_BRANCH_NAME}
+        {/if}
+        {#if import.meta.env.VITE_BUILD_ENV === "development"}
+          {import.meta.env.VITE_BUILD_ENV}
+        {/if}
+      </div>
       <div class="flex w-full text-2xl opacity-70">Intech Studio</div>
 
       <button


### PR DESCRIPTION
## Summary
- **console.error → ErrorConsole overlay:** Monkey-patches `console.error` in `ErrorConsole.svelte` `onMount` to surface logged errors in the in-app error overlay. The original `console.error` is still called so DevTools output is unaffected, and stack traces are extracted from any `Error` instances in the args.
- **Gated to dev/nightly builds:** The overlay mirroring only runs when `VITE_BUILD_ENV` is `development` or `nightly`, keeping stable releases quiet for end users.
- **Show build type in Welcome modal:** The Welcome modal title now displays the nightly branch name / `development` label next to the version, matching the Titlebar convention. Stable builds show only the version.
- **Remove unused alpha build configuration:** Drops the `alpha` branch from the electron-builder `productName` logic and the `export:alpha` npm script. Alpha builds are not used anywhere (no CI workflow references them).

## Test plan
- [ ] On a dev/nightly build, trigger a `console.error` and confirm it appears in the ErrorConsole overlay
- [ ] On a stable (production) build, confirm `console.error` does NOT pop the overlay
- [ ] Confirm DevTools console still shows the error as before
- [ ] Confirm existing uncaught exception / unhandled rejection display is unaffected
- [ ] Open the Welcome modal on nightly/dev and confirm the build type appears next to the version
- [ ] Confirm stable/nightly builds still produce correct product names via electron-builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)