### PR TITLE
Fix firmware save NotAllowedError in Electron

### DIFF
--- a/src/renderer/main/firmware_update.ts
+++ b/src/renderer/main/firmware_update.ts
@@ -147,8 +147,11 @@ export async function saveFile(data, filename) {
     // Create blob for the binary data
     const blob = new Blob([data], { type: "application/octet-stream" });
 
-    // Check if File System Access API is available (Chrome/Edge)
-    if (window.showSaveFilePicker) {
+    // In Electron, createWritable() is blocked by the sandbox even when
+    // showSaveFilePicker is available — use anchor download instead.
+    const isElectron = import.meta.env.VITE_BUILD_TARGET !== "web";
+
+    if (!isElectron && window.showSaveFilePicker) {
       const handle = await window.showSaveFilePicker({
         suggestedName: filename,
         types: [


### PR DESCRIPTION
## Summary
- `showSaveFilePicker()` succeeds in Electron but `createWritable()` is blocked by the renderer sandbox, leaving a 0-byte file on disk
- Skip the File System Access API path in Electron builds (`VITE_BUILD_TARGET !== "web"`) and fall through to the anchor-download fallback
- The anchor download triggers Electron's native save dialog, which works correctly
- Web build behavior is unchanged

## Test plan
- [ ] Open manual firmware options, download and extract a firmware ZIP, click a firmware file button
- [ ] Confirm a native save dialog appears and the saved `.uf2` file has the correct size
- [ ] Confirm no `NotAllowedError` in console and no 0-byte file is created
- [ ] Confirm web build still uses `showSaveFilePicker` when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)