### PR TITLE
Bump editor version to 1.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grid-editor",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grid-editor",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "hasInstallScript": true,
       "dependencies": {
         "@intechstudio/grid-protocol": "1.20260520.959",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "grid-editor",
   "productName": "Grid Editor",
   "description": "Powerful Editor software for Intech Studio products.",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=11.0.0"


### PR DESCRIPTION
## Summary
- Bumps `package.json` and `package-lock.json` version from `1.6.7` to `1.6.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)