### PR TITLE
More agile code block edit flow (#1390)

### DIFF
--- a/playwright-tests/data/actionBlockElements.json
+++ b/playwright-tests/data/actionBlockElements.json
@@ -65,7 +65,7 @@
     "Encoder Push & Rotate": ["push rotate", "just rotate", "end"]
   },
   "code": {
-    "Code Block": ["input", "Edit Code"],
+    "Code Block": ["input", "Open Editor"],
     "Comment Block": ["input"],
     "Element Name": ["input"]
   },

--- a/playwright-tests/data/actionBlockLocators.js
+++ b/playwright-tests/data/actionBlockLocators.js
@@ -296,8 +296,8 @@ export const blocks = (page) => ({
     "Code Block": {
       block: page.locator("#action-menu").getByText("Code Block"),
       elements: {
-        input: page.locator("pre"),
-        "Edit Code": page.getByRole("button", { name: "Edit Code" }),
+        input: page.locator("code-block .view-line").first(),
+        "Open Editor": page.getByRole("button", { name: "Open Editor" }),
       },
     },
     "Comment Block": {

--- a/playwright-tests/pages/configPage.js
+++ b/playwright-tests/pages/configPage.js
@@ -189,7 +189,10 @@ export class ConfigPage {
   // Element and Action Operations
 
   async selectAllActions() {
-    await this.configFocus.click();
+    // Focus the config panel itself rather than clicking into the area (which
+    // can land in an inline code editor that captures Ctrl+A as select-text),
+    // so the select-all-actions shortcut actually fires.
+    await this.page.locator(".configpanel").first().focus();
     await this.keyboardActions.selectAll();
   }
 

--- a/playwright-tests/pages/configPage.js
+++ b/playwright-tests/pages/configPage.js
@@ -76,9 +76,18 @@ export class ConfigPage {
       .filter({ hasText: "End" })
       .locator("action-placeholder div")
       .first();
-    this.commitCodeButton = page.getByRole("button", { name: "Commit" });
-    this.closeCodeButton = page.getByRole("button", { name: "Close" });
-    this.codeblockInput = page.locator(".view-line").first();
+    // The code block now has an inline editor with its own Commit button, so
+    // scope these to the full-screen editor modal (#monaco-container and its
+    // parent, which holds the modal's Commit/Close buttons).
+    this.commitCodeButton = page
+      .locator("#monaco-container")
+      .locator("xpath=..")
+      .getByRole("button", { name: "Commit" });
+    this.closeCodeButton = page
+      .locator("#monaco-container")
+      .locator("xpath=..")
+      .getByRole("button", { name: "Close" });
+    this.codeblockInput = page.locator("#monaco-container .view-line").first();
     this.codeBlockCharacterLimitMessage = page.getByText(
       "Config limit reached.",
     );
@@ -100,11 +109,13 @@ export class ConfigPage {
   }
 
   async openAndAddActionBlock(category, blockName) {
+    await this.resetTransientUi();
     await this.addActionBlockButton.click();
     await this.blocks[category][blockName]["block"].click();
   }
 
   async openActionBlockList() {
+    await this.resetTransientUi();
     await this.addActionBlockButton.click();
   }
 
@@ -196,6 +207,26 @@ export class ConfigPage {
 
   async clearElement() {
     await this.elementButtons.clear.click();
+    // Clearing raises a transient progress toast ("Clearing element
+    // configuration..." → "...was reset to default!") that overlays the UI and
+    // can intercept the next click — including in a following test, since the
+    // page is shared across the spec. Reset it so it can't bleed across.
+    await this.resetTransientUi();
+  }
+
+  // Reset transient, page-level UI that bleeds across tests on the shared page:
+  // notification toasts (which otherwise linger ~5s) via the web build's test
+  // hook, and any leftover-open action menu / popover (Escape). Both can
+  // overlay and intercept a later click.
+  async resetTransientUi() {
+    await this.page
+      .evaluate(() => window.__gridTest?.resetLogStream?.())
+      .catch(() => {});
+    // Close any leftover-open action menu. Its search input is auto-focused and
+    // swallows Escape, so blur first to let the key reach the menu's
+    // document-level Escape handler.
+    await this.page.evaluate(() => document.activeElement?.blur());
+    await this.page.keyboard.press("Escape");
   }
 
   async copyAction() {
@@ -244,8 +275,9 @@ export class ConfigPage {
 
   async addAndEditCodeBlock(code) {
     await this.addCodeBlock();
-    await this.blocks["code"]["Code Block"]["elements"]["Edit Code"].click();
-    await this.page.getByText("Synced with Grid!").click();
+    await this.blocks["code"]["Code Block"]["elements"]["Open Editor"].click();
+    // Both the inline block and the modal show this status, so target one.
+    await this.page.getByText("Synced with Grid!").first().click();
     await this.codeblockInput.click({ clickCount: 1 });
 
     await this.keyboardActions.selectAll();

--- a/playwright-tests/pages/modulePage.js
+++ b/playwright-tests/pages/modulePage.js
@@ -93,8 +93,14 @@ export class ModulePage {
       name: "Actions have been copied",
     });
 
-    this.characterLimitPasteToast = page.getByText("Modifications can not");
-    this.characterLimitAddToast = page.getByText("Modifications can not");
+    // The same toast can stack (one per affected module/event), so target one
+    // to avoid strict-mode violations.
+    this.characterLimitPasteToast = page
+      .getByText("Modifications can not")
+      .first();
+    this.characterLimitAddToast = page
+      .getByText("Modifications can not")
+      .first();
     this.storeButton = page.getByRole("button", { name: "Store" });
     this.clearButton = page.getByRole("button", { name: "Clear" });
     this.confirmClearButton = page.getByRole("button", {

--- a/playwright-tests/tests/actionBlockExistence.spec.js
+++ b/playwright-tests/tests/actionBlockExistence.spec.js
@@ -26,6 +26,9 @@ async function setupModule(moduleName) {
   await connectModulePage.addModule(moduleName);
 }
 async function changeModuleIfNeeded(category) {
+  // A prior test can leave the action menu open / a toast up on the shared
+  // page, which would intercept the "Remove Module" click below.
+  await configPage.resetTransientUi();
   if (category === "specialButton") {
     await modulePage.removeModule();
     await setupModule("BU16");

--- a/playwright-tests/tests/blocksTests.spec.js
+++ b/playwright-tests/tests/blocksTests.spec.js
@@ -38,7 +38,7 @@ test.describe("Issues", () => {
     await configPage.selectAllActions();
     await page
       .getByTestId("action-block")
-      .filter({ hasText: 'Code preview: print("hello")' })
+      .filter({ hasText: 'print("hello")' })
       .getByTestId(/^action-checkbox/)
       .click(); //uncheck codeblock
     await configPage.removeAction();

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -32,6 +32,7 @@
   import { debug_lowlevel_store } from "./main/panels/WebsocketMonitor/WebsocketMonitor.store";
 
   import { logger } from "./runtime/runtime.store";
+  import { logStreamStore } from "./main/user-interface/cursor-log/LogStream.store";
 
   import MiddlePanelContainer from "./main/MiddlePanelContainer.svelte";
   import PanelToggleButton from "./main/PanelToggleButton.svelte";
@@ -285,6 +286,14 @@
   //Disable Context Menu
   onMount(async () => {
     document.addEventListener("contextmenu", preventContextMenuEvent);
+    // Test-only seam: let the (web build) e2e suite reset transient UI state —
+    // notification toasts that otherwise linger ~5s and bleed across tests.
+    if (import.meta.env.VITE_BUILD_TARGET === "web") {
+      (window as any).__gridTest = {
+        ...(window as any).__gridTest,
+        resetLogStream: () => logStreamStore.reset(),
+      };
+    }
     loaded = true;
     window.electron.appLoaded();
   });

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -38,72 +38,74 @@
 </script>
 
 <script lang="ts">
-  import { GridAction, ActionData } from "./../runtime/runtime";
-  import { GridScript } from "@intechstudio/grid-protocol";
-
-  import { onDestroy } from "svelte";
-
-  import SendFeedback from "../main/user-interface/SendFeedback.svelte";
+  import { createEventDispatcher, onDestroy } from "svelte";
+  import { GridAction, GridElement, GridEvent } from "./../runtime/runtime";
+  import { type ElementType } from "@intechstudio/grid-protocol";
 
   import { MoltenPushButton } from "@intechstudio/grid-uikit";
-  import { copyContextMenu } from "../main/_actions/copy-context-menu.action";
-  import MoltenPopup from "../main/panels/preferences/MoltenPopup.svelte";
 
   import { Modal } from "../main/modals/modal.store";
   import { activeMonacoSession } from "../main/modals/monaco-session.store";
   import Monaco from "../main/modals/Monaco.svelte";
-  import { MonacoEditor } from "../lib/monaco";
-  import { appSettings } from "../runtime/app-helper.store";
+  import CodeEditor from "../main/user-interface/CodeEditor.svelte";
+  import CommitStatus from "../main/user-interface/CommitStatus.svelte";
 
   export let action: GridAction;
 
-  let codePreview: HTMLElement;
+  const dispatch = createEventDispatcher();
 
-  const lualogo_foreground = "#808080";
-  const lualogo_background = "#212a2c";
+  let codeEditor: CodeEditor;
+  let commitEnabled = false;
+  let errorMessage = "";
 
-  const lualogo = `<svg version="1.0" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100%" height="100%" viewBox="0 0 947 947" enable-background="new 0 0 947 947" xml:space="preserve">
-<g>
-	<path fill="${lualogo_foreground}" d="M835.5,473.6c0-199.8-162.2-362-362-362s-362,162.2-362,362c0,199.8,162.2,362,362,362
-		S835.5,673.4,835.5,473.6"/>
-	<path fill="${lualogo_background}" d="M729.5,323.6c0-58.5-47.5-106-106-106s-106,47.5-106,106c0,58.5,47.5,106,106,106S729.5,382.1,729.5,323.6"
-		/>
-	<path fill="${lualogo_foreground}" d="M941.5,111.5c0-58.5-47.5-106-106-106s-106,47.5-106,106c0,58.5,47.5,106,106,106S941.5,170.1,941.5,111.5"
-		/>
-	<g>
-		<path fill="${lualogo_background}" d="M258.1,627.8h117.3v26.7H227.8V417h30.3V627.8z"/>
-		<path fill="${lualogo_background}" d="M515.5,654.5v-23.8c-16,22.5-31.9,31.3-57,31.3c-33.2,0-54.4-18.2-54.4-46.6V483.8h27v120.9
-			c0,20.5,13.7,33.6,35.2,33.6c28.3,0,46.6-22.8,46.6-57.7v-96.8h27v170.7H515.5z"/>
-		<path fill="${lualogo_background}" d="M738.4,659.1c-8.8,2.3-13,2.9-18.6,2.9c-17.6,0-26.1-7.8-28-25.1c-19.2,17.6-36.5,25.1-58,25.1
-			c-34.5,0-56-19.5-56-50.5c0-22.2,10.1-37.5,30-45.6c10.4-4.2,16.3-5.5,54.7-10.4c21.5-2.6,28.3-7.5,28.3-18.9v-7.2
-			c0-16.3-13.7-25.4-38.1-25.4c-25.4,0-37.8,9.4-40.1,30.3h-27.4c0.7-16.9,3.9-26.7,11.7-35.5c11.4-12.7,31.9-19.9,56.7-19.9
-			c42,0,64.2,16.3,64.2,46.6v100.4c0,8.5,5.2,13.4,14.7,13.4c1.6,0,2.9,0,5.9-0.7V659.1z M690.8,570.1c-9.1,4.2-15,5.5-43.7,9.4
-			c-29,4.2-41.1,13.4-41.1,31.3c0,17.3,12.4,27.4,33.6,27.4c16,0,29.3-5.2,40.4-15.3c8.1-7.5,10.8-13,10.8-22.2V570.1z"/>
-	</g>
-	<path fill="none" stroke="${lualogo_foreground}" stroke-width="10.8612" stroke-miterlimit="10" stroke-dasharray="40.8475" d="M890.6,261
-		c33.5,65.8,51,138.6,51,212.5c0,258.4-209.7,468.1-468.1,468.1S5.4,731.9,5.4,473.5C5.4,215.1,215.1,5.4,473.5,5.4
-		c83.1,0,164.6,22.1,236.2,63.9"/>
-</g>
-</svg>`;
+  $: elementType = ((action.parent as GridEvent)?.parent as GridElement)
+    ?.type as ElementType;
 
-  onDestroy(() => {
-    codePreview.removeEventListener("wheel", (evt) => {
-      evt.preventDefault();
-      codePreview.scrollLeft += evt.deltaY;
-    });
-  });
+  // Disable inline editing only for the block whose code is open in the full
+  // editor modal, so the two editors can't fight over the same action. Other
+  // blocks stay editable (issue #1390, part 2).
+  $: editingInModal = $activeMonacoSession?.action === action;
 
-  function handleActionChange(data: ActionData, theme: MonacoEditor.Theme) {
-    codePreview.innerHTML = GridScript.expandScript(data.script);
-    MonacoEditor.colorize(codePreview, theme);
+  // The inline editor has uncommitted changes (edited script or a syntax error).
+  $: inlineDirty = commitEnabled || errorMessage !== "";
+
+  // Propagate the inline editor's syntax-error state to the action so the
+  // block is flagged invalid (red border), like other action blocks do. The
+  // committed script is kept; only the validity flag is toggled.
+  let hadError = false;
+  $: {
+    const hasError = errorMessage !== "";
+    if (hasError !== hadError) {
+      hadError = hasError;
+      dispatch("update-action", {
+        short: action.information.short,
+        script: action.script,
+        validationError: hasError,
+      });
+    }
   }
 
-  $: if (codePreview && !$action.invalid) {
-    const theme = $appSettings.persistent.lightMode
-      ? MonacoEditor.Theme.LIGHT
-      : MonacoEditor.Theme.DARK;
-    handleActionChange($action, theme);
+  // The invalid flag is set without touching the script, so revertToSynced
+  // can't clear it. Clear it ourselves when the editor is torn down (navigating
+  // away or collapsing the block) so the block doesn't stay flagged invalid.
+  onDestroy(() => {
+    if (hadError) {
+      dispatch("update-action", {
+        short: action.information.short,
+        script: action.synced,
+        validationError: false,
+      });
+    }
+  });
+
+  // When the modal closes for this block, reload the inline editor from the
+  // committed script so discarded modal edits don't linger inline.
+  let wasEditingInModal = false;
+  $: {
+    if (wasEditingInModal && !editingInModal) {
+      codeEditor?.reset();
+    }
+    wasEditingInModal = editingInModal;
   }
 
   // Block editing on every code block while an editor has unsaved changes —
@@ -132,52 +134,75 @@
       showAsUnique: true,
     }).show({
       monaco_action: action,
+      // Carry uncommitted inline edits into the modal so it opens on the
+      // current content rather than the last committed state.
+      initial_value: inlineDirty ? codeEditor?.getValue() : undefined,
     });
   }
 </script>
 
-<code-block class="w-full flex flex-col p-4 pb-2 pointer-events-auto">
-  <div class="w-full flex flex-col">
-    <div class="text-gray-500 text-sm font-bold">Code preview:</div>
-
-    <div class="grid w-full">
-      <pre
-        on:dblclick={open_monaco}
-        use:copyContextMenu
-        class="bg-black/25 my-4 p-2 w-full overflow-x-auto border border-black select-text"
-        bind:this={codePreview}
-        data-lang="intech_lua"
-      />
-    </div>
-
-    <div class="flex flex-row gap-2">
+<code-block class="relative w-full flex flex-col p-4 pb-2 pointer-events-auto">
+  <div
+    class="w-full flex flex-col"
+    class:grayscale={editingInModal}
+    class:opacity-50={editingInModal}
+  >
+    <div class="flex flex-row gap-2 items-center mb-2">
+      <CommitStatus {commitEnabled} />
+      <div class="flex-grow" />
       <MoltenPushButton
         click={open_monaco}
         disabled={editDisabled}
-        text={"Edit Code"}
+        text={"Open Editor"}
+      />
+      <MoltenPushButton
+        click={() => codeEditor.reset()}
+        disabled={!inlineDirty || editingInModal}
+        text={"Discard"}
+      />
+      <MoltenPushButton
+        click={() => codeEditor.commit()}
+        disabled={!commitEnabled || editingInModal}
+        text={"Commit"}
         style={"accept"}
       />
-      <div class="flex-grow" />
-      <MoltenPushButton
-        click={() =>
-          navigator.clipboard.writeText(
-            GridScript.expandScript($action.script),
-          )}
-        text={"Copy Code"}
+    </div>
+
+    <div class="w-full border border-background-soft bg-background-muted">
+      <CodeEditor
+        bind:this={codeEditor}
+        bind:commitEnabled
+        bind:errorMessage
+        {action}
+        name={$action.name}
+        restrictScope={elementType}
+        readOnly={editingInModal}
+        minLines={5}
+        maxLines={20}
+        lineNumbers={false}
+        wordWrap={false}
+        suggestions={false}
+      />
+    </div>
+
+    {#if errorMessage}
+      <div
+        class="text-left text-sm text-error whitespace-pre-line max-h-24 overflow-y-auto mt-2"
       >
-        <MoltenPopup slot="popup" text="Copied to clipboard!" />
-      </MoltenPushButton>
-    </div>
+        {errorMessage}
+      </div>
+    {/if}
   </div>
 
-  <div class="flex flex-row mt-4">
-    <div class="w-full flex flex-col">
-      <div class="text-gray-500 font-bold -mb-2">Powered by Lua</div>
-      <SendFeedback feedback_context="CodeBlock" />
+  {#if editingInModal}
+    <div
+      class="absolute inset-0 flex items-center justify-center pointer-events-auto"
+    >
+      <span
+        class="text-lg font-bold text-foreground-muted [text-shadow:0_0_6px_var(--background),0_0_6px_var(--background),0_0_6px_var(--background),0_0_12px_var(--background),0_0_12px_var(--background)]"
+      >
+        Currently open in editor window!
+      </span>
     </div>
-
-    <div class="h-12 w-12">
-      {@html lualogo}
-    </div>
-  </div>
+  {/if}
 </code-block>

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -50,6 +50,7 @@
   import MoltenPopup from "../main/panels/preferences/MoltenPopup.svelte";
 
   import { Modal } from "../main/modals/modal.store";
+  import { activeMonacoSession } from "../main/modals/monaco-session.store";
   import Monaco from "../main/modals/Monaco.svelte";
   import { MonacoEditor } from "../lib/monaco";
   import { appSettings } from "../runtime/app-helper.store";
@@ -105,7 +106,26 @@
     handleActionChange($action, theme);
   }
 
+  // Block editing on every code block while an editor has unsaved changes —
+  // it can't be auto-replaced until it's committed or discarded (issue #1390).
+  $: editDisabled = !!$activeMonacoSession && $activeMonacoSession.dirty;
+
   async function open_monaco() {
+    const session = $activeMonacoSession;
+    if (session) {
+      // Editor is already showing this block — nothing to do.
+      if (session.action === action) {
+        return;
+      }
+      // Another block is open with unsaved changes: leave it be so the user
+      // doesn't silently lose work (matches the pre-existing behavior).
+      if (session.dirty) {
+        return;
+      }
+      // Clean editor: auto-close it so it can be replaced by this block.
+      session.close();
+    }
+
     new Modal.Window(Monaco, Modal.Snap.GridLayout, {
       disableClickOutside: true,
       disableEscapeClose: true,
@@ -133,6 +153,7 @@
     <div class="flex flex-row gap-2">
       <MoltenPushButton
         click={open_monaco}
+        disabled={editDisabled}
         text={"Edit Code"}
         style={"accept"}
       />

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -162,26 +162,28 @@
     class:grayscale={editingInModal}
     class:opacity-50={editingInModal}
   >
-    <div class="flex flex-row gap-2 items-center mb-2">
+    <div class="flex flex-row gap-2 items-center mb-2 flex-wrap">
       <CommitStatus {commitEnabled} />
       <div class="flex-grow" />
-      <MoltenPushButton
-        click={open_monaco}
-        disabled={editDisabled}
-        text={"Open Editor"}
-      />
-      <MoltenPushButton
-        click={() => codeEditor.reset()}
-        disabled={!inlineDirty || editingInModal}
-        text={"Discard"}
-      />
-      <div bind:this={commitButton} class="contents">
+      <div class="flex flex-row gap-2 items-center">
         <MoltenPushButton
-          click={() => codeEditor.commit()}
-          disabled={!commitEnabled || editingInModal}
-          text={"Commit"}
-          style={"accept"}
+          click={open_monaco}
+          disabled={editDisabled}
+          text={"Open Editor"}
         />
+        <MoltenPushButton
+          click={() => codeEditor.reset()}
+          disabled={!inlineDirty || editingInModal}
+          text={"Discard"}
+        />
+        <div bind:this={commitButton} class="contents">
+          <MoltenPushButton
+            click={() => codeEditor.commit()}
+            disabled={!commitEnabled || editingInModal}
+            text={"Commit"}
+            style={"accept"}
+          />
+        </div>
       </div>
     </div>
 

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -55,8 +55,20 @@
   const dispatch = createEventDispatcher();
 
   let codeEditor: CodeEditor;
+  let commitButton: HTMLElement;
   let commitEnabled = false;
   let errorMessage = "";
+
+  // Ctrl/Cmd+S inside this block commits it. Caught here (not via a Monaco
+  // keybinding) so it's scoped to the block: we stop propagation and trigger
+  // the Commit button — which no-ops on its own when disabled.
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+      e.preventDefault();
+      e.stopPropagation();
+      commitButton?.querySelector("button")?.click();
+    }
+  }
 
   $: elementType = ((action.parent as GridEvent)?.parent as GridElement)
     ?.type as ElementType;
@@ -141,7 +153,10 @@
   }
 </script>
 
-<code-block class="relative w-full flex flex-col p-4 pb-2 pointer-events-auto">
+<code-block
+  class="relative w-full flex flex-col p-4 pb-2 pointer-events-auto"
+  on:keydown={handleKeydown}
+>
   <div
     class="w-full flex flex-col"
     class:grayscale={editingInModal}
@@ -160,12 +175,14 @@
         disabled={!inlineDirty || editingInModal}
         text={"Discard"}
       />
-      <MoltenPushButton
-        click={() => codeEditor.commit()}
-        disabled={!commitEnabled || editingInModal}
-        text={"Commit"}
-        style={"accept"}
-      />
+      <div bind:this={commitButton} class="contents">
+        <MoltenPushButton
+          click={() => codeEditor.commit()}
+          disabled={!commitEnabled || editingInModal}
+          text={"Commit"}
+          style={"accept"}
+        />
+      </div>
     </div>
 
     <div class="w-full border border-background-soft bg-background-muted">

--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -187,7 +187,7 @@
       </div>
     </div>
 
-    <div class="w-full border border-background-soft bg-background-muted">
+    <div class="w-full h-32 border border-background-soft bg-background-muted">
       <CodeEditor
         bind:this={codeEditor}
         bind:commitEnabled
@@ -196,8 +196,8 @@
         name={$action.name}
         restrictScope={elementType}
         readOnly={editingInModal}
-        minLines={5}
-        maxLines={20}
+        minLines={7}
+        maxLines={7}
         lineNumbers={false}
         wordWrap={false}
         suggestions={false}

--- a/src/renderer/main/modals/Monaco.svelte
+++ b/src/renderer/main/modals/Monaco.svelte
@@ -17,6 +17,8 @@
   import { onDestroy, tick } from "svelte";
   import { NumberToEventType, GridScript } from "@intechstudio/grid-protocol";
   import { Modal, modalManager } from "./modal.store";
+  import { activeMonacoSession } from "./monaco-session.store";
+  import { get } from "svelte/store";
   import MoltenModal from "./MoltenModal.svelte";
   import { onMount } from "svelte";
   import { appSettings } from "../../runtime/app-helper.store";
@@ -43,6 +45,7 @@
   let nameInput;
   let clickedOutside = false;
   let monaco_disposables = [];
+  const sessionToken = {};
 
   class LengthError extends String {}
 
@@ -117,11 +120,27 @@
     });
 
     editor.onDidChangeModelContent(handleContentChange);
+
+    activeMonacoSession.set({
+      token: sessionToken,
+      action: monaco_action,
+      dirty,
+      close: () => data.close(),
+    });
   });
 
   $: if (editor) {
     handleLightModeChange($appSettings.persistent.lightMode);
   }
+
+  // "Needs committing": unsaved changes or an unresolved error.
+  $: dirty = commitEnabled || errorMessage !== "";
+
+  // Keep the shared session in sync so other code blocks can react to whether
+  // this editor currently needs committing (issue #1390, part 1).
+  $: activeMonacoSession.update((s) =>
+    s?.token === sessionToken ? { ...s, dirty } : s,
+  );
 
   function handleLightModeChange(value: boolean) {
     MonacoEditor.setTheme(
@@ -172,6 +191,9 @@
 
   onDestroy(() => {
     monaco_disposables.forEach((d) => d.dispose());
+    if (get(activeMonacoSession)?.token === sessionToken) {
+      activeMonacoSession.set(null);
+    }
   });
 
   function handleClose() {

--- a/src/renderer/main/modals/Monaco.svelte
+++ b/src/renderer/main/modals/Monaco.svelte
@@ -269,12 +269,6 @@
         </div>
         <MoltenPushButton click={handleClose} text="Close" style="normal" />
       </div>
-
-      <div
-        class="text-left text-sm text-error whitespace-pre-line min-h-10 max-h-24 overflow-y-auto"
-      >
-        {errorMessage}
-      </div>
     </div>
 
     <div
@@ -302,6 +296,12 @@
         restrictScope={element?.type}
         initialValue={initial_value}
       />
+    </div>
+
+    <div
+      class="text-left text-sm text-error whitespace-pre-line min-h-10 max-h-24 overflow-y-auto w-full"
+    >
+      {errorMessage}
     </div>
 
     <div class="h-1/4 flex w-full">

--- a/src/renderer/main/modals/Monaco.svelte
+++ b/src/renderer/main/modals/Monaco.svelte
@@ -63,6 +63,7 @@
   export let initial_value: string | undefined = undefined;
 
   let codeEditor: CodeEditor;
+  let commitButton: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor | undefined;
   let commitEnabled = false;
   let errorMessage = "";
@@ -181,6 +182,16 @@
     clickedOutside = true;
   }
 
+  // Ctrl/Cmd+S commits the editor by triggering the Commit button, which
+  // no-ops on its own when disabled. Scoped to this modal's content subtree.
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+      e.preventDefault();
+      e.stopPropagation();
+      commitButton?.querySelector("button")?.click();
+    }
+  }
+
   function handleWindowKeydown(e: KeyboardEvent) {
     if (modalManager.getTop() !== data) {
       return;
@@ -216,6 +227,7 @@
     slot="content"
     class="h-full w-full relative flex flex-col gap-2 items-start text-foreground"
     use:watchResize={handleResize}
+    on:keydown={handleKeydown}
   >
     <div class="flex flex-col w-full gap-2">
       <div class="flex flex-row w-full items-center gap-4">
@@ -247,12 +259,14 @@
 
         <CommitStatus {commitEnabled} deleted={isDeleted($monaco_action)} />
 
-        <MoltenPushButton
-          click={() => codeEditor.commit()}
-          disabled={!commitEnabled || isDeleted($monaco_action)}
-          text="Commit"
-          style="accept"
-        />
+        <div bind:this={commitButton} class="contents">
+          <MoltenPushButton
+            click={() => codeEditor.commit()}
+            disabled={!commitEnabled || isDeleted($monaco_action)}
+            text="Commit"
+            style="accept"
+          />
+        </div>
         <MoltenPushButton click={handleClose} text="Close" style="normal" />
       </div>
 

--- a/src/renderer/main/modals/Monaco.svelte
+++ b/src/renderer/main/modals/Monaco.svelte
@@ -14,46 +14,69 @@
     MoltenPushButton,
     SvgIcon,
   } from "@intechstudio/grid-uikit";
-  import { onDestroy, tick } from "svelte";
-  import { NumberToEventType, GridScript } from "@intechstudio/grid-protocol";
+  import { onDestroy, onMount } from "svelte";
+  import { NumberToEventType } from "@intechstudio/grid-protocol";
   import { Modal, modalManager } from "./modal.store";
   import { activeMonacoSession } from "./monaco-session.store";
   import { get } from "svelte/store";
   import MoltenModal from "./MoltenModal.svelte";
-  import { onMount } from "svelte";
-  import { appSettings } from "../../runtime/app-helper.store";
   import { clickOutside } from "../_actions/click-outside.action";
-  import { updateAction } from "../../runtime/operations";
   import { MonacoEditor } from "../../lib/monaco";
+  import CodeEditor from "../user-interface/CodeEditor.svelte";
+  import CommitStatus from "../user-interface/CommitStatus.svelte";
+  import CharacterCount from "../user-interface/CharacterCount.svelte";
+  import SendFeedback from "../user-interface/SendFeedback.svelte";
   import DebugTextList from "../panels/DebugMonitor/DebugTextList.svelte";
   import ConfirmModal from "./ConfirmModal.svelte";
 
+  const lualogo_foreground = "#808080";
+  const lualogo_background = "#212a2c";
+
+  const lualogo = `<svg version="1.0" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="100%" height="100%" viewBox="0 0 947 947" enable-background="new 0 0 947 947" xml:space="preserve">
+<g>
+	<path fill="${lualogo_foreground}" d="M835.5,473.6c0-199.8-162.2-362-362-362s-362,162.2-362,362c0,199.8,162.2,362,362,362
+		S835.5,673.4,835.5,473.6"/>
+	<path fill="${lualogo_background}" d="M729.5,323.6c0-58.5-47.5-106-106-106s-106,47.5-106,106c0,58.5,47.5,106,106,106S729.5,382.1,729.5,323.6"
+		/>
+	<path fill="${lualogo_foreground}" d="M941.5,111.5c0-58.5-47.5-106-106-106s-106,47.5-106,106c0,58.5,47.5,106,106,106S941.5,170.1,941.5,111.5"
+		/>
+	<g>
+		<path fill="${lualogo_background}" d="M258.1,627.8h117.3v26.7H227.8V417h30.3V627.8z"/>
+		<path fill="${lualogo_background}" d="M515.5,654.5v-23.8c-16,22.5-31.9,31.3-57,31.3c-33.2,0-54.4-18.2-54.4-46.6V483.8h27v120.9
+			c0,20.5,13.7,33.6,35.2,33.6c28.3,0,46.6-22.8,46.6-57.7v-96.8h27v170.7H515.5z"/>
+		<path fill="${lualogo_background}" d="M738.4,659.1c-8.8,2.3-13,2.9-18.6,2.9c-17.6,0-26.1-7.8-28-25.1c-19.2,17.6-36.5,25.1-58,25.1
+			c-34.5,0-56-19.5-56-50.5c0-22.2,10.1-37.5,30-45.6c10.4-4.2,16.3-5.5,54.7-10.4c21.5-2.6,28.3-7.5,28.3-18.9v-7.2
+			c0-16.3-13.7-25.4-38.1-25.4c-25.4,0-37.8,9.4-40.1,30.3h-27.4c0.7-16.9,3.9-26.7,11.7-35.5c11.4-12.7,31.9-19.9,56.7-19.9
+			c42,0,64.2,16.3,64.2,46.6v100.4c0,8.5,5.2,13.4,14.7,13.4c1.6,0,2.9,0,5.9-0.7V659.1z M690.8,570.1c-9.1,4.2-15,5.5-43.7,9.4
+			c-29,4.2-41.1,13.4-41.1,31.3c0,17.3,12.4,27.4,33.6,27.4c16,0,29.3-5.2,40.4-15.3c8.1-7.5,10.8-13,10.8-22.2V570.1z"/>
+	</g>
+	<path fill="none" stroke="${lualogo_foreground}" stroke-width="10.8612" stroke-miterlimit="10" stroke-dasharray="40.8475" d="M890.6,261
+		c33.5,65.8,51,138.6,51,212.5c0,258.4-209.7,468.1-468.1,468.1S5.4,731.9,5.4,473.5C5.4,215.1,215.1,5.4,473.5,5.4
+		c83.1,0,164.6,22.1,236.2,63.9"/>
+</g>
+</svg>`;
+
   export let data: Modal.Instance;
   export let monaco_action: GridAction;
+  // Optional uncommitted content carried over from the inline editor.
+  export let initial_value: string | undefined = undefined;
 
-  let event: GridEvent;
-  let element: GridElement;
-  let monaco_block;
-  let editor;
+  let codeEditor: CodeEditor;
+  let editor: MonacoEditor.CustomCodeEditor | undefined;
   let commitEnabled = false;
   let errorMessage = "";
-  let commited = { script: "", name: "" };
-  let scriptLength = undefined;
+  let scriptLength: number | undefined = undefined;
   let pathSnippets = [];
   let name;
   let isEditName = false;
   let nameInput;
   let clickedOutside = false;
-  let monaco_disposables = [];
   const sessionToken = {};
 
-  class LengthError extends String {}
-
-  $: handleFontSizechange($appSettings.persistent.fontSize);
-
-  function handleFontSizechange(fontSize) {
-    editor?.updateOptions({ fontSize });
-  }
+  // Element type drives autocomplete scope; available synchronously for the
+  // CodeEditor child's initial mount.
+  const element = (monaco_action.parent as GridEvent)?.parent as GridElement;
 
   $: handleActionChange($monaco_action);
 
@@ -90,37 +113,7 @@
     ];
   }
 
-  onMount(async () => {
-    await tick();
-    event = monaco_action.parent as GridEvent;
-    element = event.parent as GridElement;
-    commited.name = monaco_action.name;
-    commited.script = monaco_action.script;
-    scriptLength = event.toLua().length;
-
-    editor = MonacoEditor.create(monaco_block, {
-      value: GridScript.expandScript(monaco_action.script),
-      language: "intech_lua",
-      theme: $appSettings.persistent.lightMode
-        ? MonacoEditor.Theme.LIGHT
-        : MonacoEditor.Theme.DARK,
-      fontSize: $appSettings.persistent.fontSize,
-      restrictScope: $element.type,
-      folding: false,
-      renderLineHighlight: "none",
-      contextmenu: false,
-      scrollBeyondLastLine: false,
-      automaticLayout: true,
-      wordWrap: "on",
-      suggest: {
-        showIcons: false,
-        showWords: true,
-      },
-      minimap: { enabled: false },
-    });
-
-    editor.onDidChangeModelContent(handleContentChange);
-
+  onMount(() => {
     activeMonacoSession.set({
       token: sessionToken,
       action: monaco_action,
@@ -128,10 +121,6 @@
       close: () => data.close(),
     });
   });
-
-  $: if (editor) {
-    handleLightModeChange($appSettings.persistent.lightMode);
-  }
 
   // "Needs committing": unsaved changes or an unresolved error.
   $: dirty = commitEnabled || errorMessage !== "";
@@ -142,55 +131,7 @@
     s?.token === sessionToken ? { ...s, dirty } : s,
   );
 
-  function handleLightModeChange(value: boolean) {
-    MonacoEditor.setTheme(
-      value ? MonacoEditor.Theme.LIGHT : MonacoEditor.Theme.DARK,
-    );
-  }
-
-  function handleContentChange() {
-    try {
-      const compressed = GridScript.compressScript(editor.getValue());
-      $monaco_action.script = compressed;
-      $monaco_action.name =
-        name !== $monaco_action?.information.displayName ? name : undefined;
-      scriptLength = ($monaco_action.parent as GridEvent).toLua().length;
-      if (scriptLength >= Grid.Protocol.maxScriptLength) {
-        throw new LengthError("Config limit reached.");
-      }
-      errorMessage = "";
-      commitEnabled =
-        $monaco_action.script !== commited.script ||
-        commited.name !== $monaco_action.name;
-    } catch (e) {
-      if (!(e instanceof LengthError)) {
-        scriptLength = undefined;
-      }
-      commitEnabled = false;
-      errorMessage = String(e).replace(/^error parsing: ?\n?/i, "");
-    }
-    $monaco_action.name = commited.name;
-    $monaco_action.script = commited.script;
-  }
-
-  async function handleCommitClicked() {
-    updateAction(
-      monaco_action,
-      new ActionData(
-        monaco_action.short,
-        GridScript.compressScript(editor.getValue()),
-        name !== $monaco_action?.information.displayName ? name : undefined,
-      ),
-      true,
-    ).then(() => {
-      commited.name = $monaco_action.name;
-      commited.script = $monaco_action.script;
-      commitEnabled = false;
-    });
-  }
-
   onDestroy(() => {
-    monaco_disposables.forEach((d) => d.dispose());
     if (get(activeMonacoSession)?.token === sessionToken) {
       activeMonacoSession.set(null);
     }
@@ -239,15 +180,6 @@
     isEditName = false;
     clickedOutside = true;
   }
-
-  function handleNameChange(value) {
-    if (value === monaco_action?.information.displayName) return;
-    if (value !== monaco_action?.name) {
-      handleContentChange();
-    }
-  }
-
-  $: handleNameChange(name);
 
   function handleWindowKeydown(e: KeyboardEvent) {
     if (modalManager.getTop() !== data) {
@@ -308,27 +240,15 @@
         </div>
 
         <span class:invisible={isDeleted($monaco_action)}>
-          {`Character Count: ${typeof scriptLength === "undefined" ? "?" : scriptLength}/${
-            Grid.Protocol.maxScriptLength - 1
-          } (max)`}
+          <CharacterCount {scriptLength} />
         </span>
 
         <div class="flex-grow"></div>
 
-        {#if isDeleted($monaco_action)}
-          <div class="text-right text-sm">Deleted Action</div>
-        {:else}
-          <div
-            class="text-right text-sm {commitEnabled
-              ? 'text-yellow-600'
-              : 'text-green-500'}"
-          >
-            {commitEnabled ? "Unsaved changes!" : "Synced with Grid!"}
-          </div>
-        {/if}
+        <CommitStatus {commitEnabled} deleted={isDeleted($monaco_action)} />
 
         <MoltenPushButton
-          click={handleCommitClicked}
+          click={() => codeEditor.commit()}
           disabled={!commitEnabled || isDeleted($monaco_action)}
           text="Commit"
           style="accept"
@@ -357,11 +277,30 @@
           {/if}
         {/each}
       </div>
-      <div bind:this={monaco_block} class="flex w-full h-full" />
+      <CodeEditor
+        bind:this={codeEditor}
+        bind:editor
+        bind:commitEnabled
+        bind:errorMessage
+        bind:scriptLength
+        bind:name
+        action={monaco_action}
+        restrictScope={element?.type}
+        initialValue={initial_value}
+      />
     </div>
 
     <div class="h-1/4 flex w-full">
       <DebugTextList />
+    </div>
+
+    <div class="flex flex-row items-center gap-2 w-full">
+      <SendFeedback feedback_context="CodeBlock" />
+      <div class="flex-grow" />
+      <div class="text-gray-500 font-bold">Powered by Lua</div>
+      <div class="h-12 w-12">
+        {@html lualogo}
+      </div>
     </div>
   </div>
 </MoltenModal>

--- a/src/renderer/main/modals/monaco-session.store.ts
+++ b/src/renderer/main/modals/monaco-session.store.ts
@@ -1,0 +1,20 @@
+import { writable } from "svelte/store";
+import type { GridAction } from "../../runtime/runtime";
+
+// Tracks the currently-open Monaco code editor so that opening a different
+// code block can decide whether it is safe to auto-close-and-replace it
+// (issue #1390, part 1). Only one Monaco editor can be open at a time.
+export type MonacoSession = {
+  // Unique per editor instance, used to guard the onDestroy cleanup against
+  // a stale instance clearing the session after a newer one registered.
+  token: object;
+  // The action currently being edited.
+  action: GridAction;
+  // True while the editor has unsaved changes or an error ("needs committing").
+  // Kept live by the editor so subscribers react as the user types.
+  dirty: boolean;
+  // Closes the editor's modal window.
+  close: () => void;
+};
+
+export const activeMonacoSession = writable<MonacoSession | null>(null);

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -353,10 +353,16 @@
 
       rawContent = assembled;
       selectedLanguage = detectLanguage(entry);
-      fileContent =
-        selectedLanguage === "lua"
-          ? GridScript.expandScript(rawContent)
-          : rawContent;
+      try {
+        fileContent =
+          selectedLanguage === "lua"
+            ? GridScript.expandScript(rawContent)
+            : rawContent;
+        luaSyntaxError = null;
+      } catch (e) {
+        fileContent = rawContent;
+        luaSyntaxError = String(e);
+      }
       savedContent = fileContent;
       editor?.setValue(fileContent ?? "");
     } catch (e) {

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -226,6 +226,17 @@
 
   let monacoElement: HTMLElement;
   let editor: MonacoEditor.CustomCodeEditor;
+  let saveButton: HTMLElement;
+
+  // Ctrl/Cmd+S saves the file by triggering the Save button, which no-ops on
+  // its own when disabled. Scoped to the editor section's subtree.
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+      e.preventDefault();
+      e.stopPropagation();
+      saveButton?.querySelector("button")?.click();
+    }
+  }
 
   const languageOptions = [
     { title: "Plain Text", value: "plaintext" },
@@ -702,6 +713,7 @@
   {/if}
 
   <div
+    onkeydown={handleKeydown}
     class="border-t border-white/10 pt-2 flex flex-col gap-1 flex-grow min-h-0 {(fileContent ===
       null &&
       !readingFile) ||
@@ -729,15 +741,17 @@
         text="Discard"
         disabled={!fileDirty}
       />
-      <MoltenPushButton
-        click={saveFile}
-        text={savingFile
-          ? uploadProgress
-            ? `${uploadProgress.current}/${uploadProgress.total}`
-            : "..."
-          : "Save"}
-        disabled={!fileDirty || savingFile || !!luaSyntaxError}
-      />
+      <div bind:this={saveButton} class="contents">
+        <MoltenPushButton
+          click={saveFile}
+          text={savingFile
+            ? uploadProgress
+              ? `${uploadProgress.current}/${uploadProgress.total}`
+              : "..."
+            : "Save"}
+          disabled={!fileDirty || savingFile || !!luaSyntaxError}
+        />
+      </div>
     </div>
     {#if luaSyntaxError}
       <p class="text-base text-red-400 font-mono">{luaSyntaxError}</p>

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -763,13 +763,6 @@
         />
       </div>
     </div>
-    {#if luaSyntaxError}
-      <p
-        class="text-sm text-error whitespace-pre-line max-h-24 overflow-y-auto font-mono"
-      >
-        {luaSyntaxError}
-      </p>
-    {/if}
     {#if readingFile}
       <p class="text-base opacity-50">
         {downloadProgress
@@ -783,5 +776,12 @@
         ? 'hidden'
         : ''}"
     />
+    {#if luaSyntaxError}
+      <p
+        class="text-sm text-error whitespace-pre-line max-h-24 overflow-y-auto font-mono"
+      >
+        {luaSyntaxError}
+      </p>
+    {/if}
   </div>
 </container>

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -684,7 +684,11 @@
     <!-- File list -->
     <div class="min-h-0">
       {#if error}
-        <p class="text-base text-red-400 select-text">{error}</p>
+        <p
+          class="text-sm text-error whitespace-pre-line max-h-24 overflow-y-auto select-text"
+        >
+          {error}
+        </p>
       {:else if loading}
         <p class="text-base opacity-50">Loading...</p>
       {:else if entries.length === 0}
@@ -754,7 +758,11 @@
       </div>
     </div>
     {#if luaSyntaxError}
-      <p class="text-base text-red-400 font-mono">{luaSyntaxError}</p>
+      <p
+        class="text-sm text-error whitespace-pre-line max-h-24 overflow-y-auto font-mono"
+      >
+        {luaSyntaxError}
+      </p>
     {/if}
     {#if readingFile}
       <p class="text-base opacity-50">

--- a/src/renderer/main/panels/configuration/ActionList.svelte
+++ b/src/renderer/main/panels/configuration/ActionList.svelte
@@ -5,8 +5,34 @@
   import DynamicWrapper from "./components/DynamicWrapper.svelte";
   import { GridEvent, GridRuntime } from "./../../../runtime/runtime";
   import { fade } from "svelte/transition";
-  import { flip } from "svelte/animate";
   import * as eases from "svelte/easing";
+
+  // FLIP-style animation that only translates (unlike svelte/animate's `flip`,
+  // which also scales). Scaling squishes the contents of any block whose height
+  // changes mid-list — e.g. a code block growing to show a syntax error — so we
+  // translate position changes only and let resized blocks grow in place.
+  function reflow(
+    node: Element,
+    { from, to }: { from: DOMRect; to: DOMRect },
+    params: {
+      delay?: number;
+      duration?: number;
+      easing?: (t: number) => number;
+    } = {},
+  ) {
+    const style = getComputedStyle(node);
+    const transform = style.transform === "none" ? "" : style.transform;
+    const dx = from.left - to.left;
+    const dy = from.top - to.top;
+    const { delay = 0, duration = 300, easing = eases.cubicOut } = params;
+    return {
+      delay,
+      duration,
+      easing,
+      css: (_t: number, u: number) =>
+        `transform: ${transform} translate(${u * dx}px, ${u * dy}px);`,
+    };
+  }
   import { addActions, pasteActions } from "../../../runtime/operations";
   import { GridAction } from "./../../../runtime/runtime";
   import { appSettings } from "./../../../runtime/app-helper.store";
@@ -168,7 +194,7 @@
 
         <div
           data-testid="action-block"
-          animate:flip={{ duration: 300, easing: eases.backOut }}
+          animate:reflow={{ duration: 300, easing: eases.cubicOut }}
           in:fade|global={{ delay: 0 }}
         >
           <div class="flex flex-row gap-2">

--- a/src/renderer/main/user-interface/CharacterCount.svelte
+++ b/src/renderer/main/user-interface/CharacterCount.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Grid } from "../../lib/_utils";
+
+  // Script length against the protocol limit, shared by the code editors.
+  export let scriptLength: number | undefined = undefined;
+</script>
+
+<span>
+  {`Character Count: ${
+    typeof scriptLength === "undefined" ? "?" : scriptLength
+  }/${Grid.Protocol.maxScriptLength - 1} (max)`}
+</span>

--- a/src/renderer/main/user-interface/CodeEditor.svelte
+++ b/src/renderer/main/user-interface/CodeEditor.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import { onDestroy, onMount, tick } from "svelte";
+  import { editor as MonacoApi } from "monaco-editor";
+  import { GridScript, type ElementType } from "@intechstudio/grid-protocol";
+  import { Grid } from "../../lib/_utils";
+  import { appSettings } from "../../runtime/app-helper.store";
+  import { MonacoEditor } from "../../lib/monaco";
+  import { GridAction, ActionData, GridEvent } from "../../runtime/runtime";
+  import { updateAction } from "../../runtime/operations";
+
+  // The action whose script is being edited.
+  export let action: GridAction;
+  // Name to persist alongside the script on commit (host owns name editing).
+  export let name: string | undefined = undefined;
+  // Autocomplete scope (element type), passed through to Monaco.
+  export let restrictScope: ElementType | undefined = undefined;
+  export let readOnly = false;
+  // Auto-size the editor to its content, clamped between minLines and maxLines
+  // (content scrolls past maxLines). When maxLines is undefined the editor fills
+  // its parent instead. Used for the in-action-block editor.
+  export let minLines = 1;
+  export let maxLines: number | undefined = undefined;
+  // Show the line-number gutter. Disabled for the compact in-action-block editor.
+  export let lineNumbers = true;
+  // Wrap long lines. When false, lines scroll horizontally instead.
+  export let wordWrap = true;
+  // Show autocomplete suggestions while typing. Disabled for the inline editor.
+  export let suggestions = true;
+  // Initial editor text (expanded form) overriding the action's committed
+  // script — used to carry uncommitted inline edits into the modal.
+  export let initialValue: string | undefined = undefined;
+
+  // Bindable state for the host (commit button, status, character count).
+  export let commitEnabled = false;
+  export let errorMessage = "";
+  export let scriptLength: number | undefined = undefined;
+  // Bindable raw editor instance, for hosts that need direct access
+  // (e.g. the modal's suggest-widget escape handling).
+  export let editor: MonacoEditor.CustomCodeEditor | undefined = undefined;
+
+  let monaco_block: HTMLElement;
+  let commited = { script: "", name: "" };
+  let disposables: { dispose: () => void }[] = [];
+
+  // Thrown for the script-length limit so it can be told apart from parse errors.
+  class LengthError extends String {}
+
+  $: autoSize = maxLines !== undefined;
+
+  $: if (editor) {
+    editor.updateOptions({ fontSize: $appSettings.persistent.fontSize });
+    updateHeight();
+  }
+
+  $: if (editor) {
+    MonacoEditor.setTheme(
+      $appSettings.persistent.lightMode
+        ? MonacoEditor.Theme.LIGHT
+        : MonacoEditor.Theme.DARK,
+    );
+  }
+
+  $: editor?.updateOptions({ readOnly });
+
+  // Reload the editor when the action's script is changed elsewhere (e.g.
+  // committed from the modal while this inline editor is showing the block),
+  // so its content stays in sync with the committed state.
+  $: syncExternalScript($action.script);
+
+  function syncExternalScript(script: string) {
+    if (!editor) return;
+    // Our own (un)committed state — nothing external changed.
+    if (script === commited.script) return;
+    commited.script = script;
+    commited.name = action.name;
+    const expanded = GridScript.expandScript(script);
+    if (editor.getValue() !== expanded) {
+      // setValue retriggers handleContentChange, which clears commitEnabled.
+      editor.setValue(expanded);
+    } else {
+      commitEnabled = false;
+    }
+  }
+
+  onMount(async () => {
+    await tick();
+    commited.name = action.name;
+    commited.script = action.script;
+    scriptLength = (action.parent as GridEvent).toLua().length;
+
+    editor = MonacoEditor.create(monaco_block, {
+      value: initialValue ?? GridScript.expandScript(action.script),
+      language: "intech_lua",
+      theme: $appSettings.persistent.lightMode
+        ? MonacoEditor.Theme.LIGHT
+        : MonacoEditor.Theme.DARK,
+      fontSize: $appSettings.persistent.fontSize,
+      restrictScope,
+      readOnly,
+      folding: false,
+      renderLineHighlight: "none",
+      contextmenu: false,
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+      wordWrap: wordWrap ? "on" : "off",
+      suggest: {
+        showIcons: false,
+        showWords: true,
+      },
+      quickSuggestions: suggestions,
+      suggestOnTriggerCharacters: suggestions,
+      minimap: { enabled: false },
+      // Hide the gutter entirely when line numbers are off, for a compact look.
+      lineNumbers: lineNumbers ? "on" : "off",
+      ...(lineNumbers
+        ? {}
+        : {
+            lineNumbersMinChars: 0,
+            glyphMargin: false,
+            lineDecorationsWidth: 0,
+          }),
+    });
+
+    disposables.push(editor.onDidChangeModelContent(handleContentChange));
+    if (autoSize) {
+      disposables.push(editor.onDidContentSizeChange(updateHeight));
+    }
+    updateHeight();
+
+    // An override may differ from the committed script, so reflect that as
+    // unsaved changes right away.
+    if (initialValue !== undefined) {
+      handleContentChange();
+    }
+  });
+
+  // Current editor text (expanded form), including uncommitted edits.
+  export function getValue() {
+    return editor?.getValue() ?? GridScript.expandScript(action.script);
+  }
+
+  // Discard any uncommitted edits and reload from the committed script.
+  export function reset() {
+    if (!editor) return;
+    const expanded = GridScript.expandScript(action.script);
+    if (editor.getValue() !== expanded) {
+      editor.setValue(expanded);
+    }
+    commited.script = action.script;
+    commited.name = action.name;
+    commitEnabled = false;
+    errorMessage = "";
+  }
+
+  onDestroy(() => {
+    disposables.forEach((d) => d.dispose());
+    editor?.dispose();
+  });
+
+  // Size the editor to its content, clamped between minLines and maxLines.
+  function updateHeight() {
+    if (!autoSize || !editor) return;
+    const lineHeight = editor.getOption(MonacoApi.EditorOption.lineHeight);
+    const height = Math.min(
+      maxLines * lineHeight,
+      Math.max(minLines * lineHeight, editor.getContentHeight()),
+    );
+    monaco_block.style.height = `${height}px`;
+    editor.layout();
+  }
+
+  // Validate the current editor content and recompute commit/error state.
+  // The action is mutated transiently only to measure the resulting event
+  // length, then restored — it is not actually changed until commit().
+  function handleContentChange() {
+    try {
+      const compressed = GridScript.compressScript(editor.getValue());
+      $action.script = compressed;
+      $action.name =
+        name !== $action?.information.displayName ? name : undefined;
+      scriptLength = ($action.parent as GridEvent).toLua().length;
+      if (scriptLength >= Grid.Protocol.maxScriptLength) {
+        throw new LengthError("Config limit reached.");
+      }
+      errorMessage = "";
+      commitEnabled =
+        $action.script !== commited.script || commited.name !== $action.name;
+    } catch (e) {
+      if (!(e instanceof LengthError)) {
+        scriptLength = undefined;
+      }
+      commitEnabled = false;
+      errorMessage = String(e).replace(/^error parsing: ?\n?/i, "");
+    }
+    $action.name = commited.name;
+    $action.script = commited.script;
+  }
+
+  function handleNameChange(value: string | undefined) {
+    if (!editor) return;
+    if (value === action?.information.displayName) return;
+    if (value !== action?.name) {
+      handleContentChange();
+    }
+  }
+
+  $: handleNameChange(name);
+
+  // Persist the current content to the action and sync it to the grid.
+  export function commit() {
+    return updateAction(
+      action,
+      new ActionData(
+        action.short,
+        GridScript.compressScript(editor.getValue()),
+        name !== $action?.information.displayName ? name : undefined,
+      ),
+      true,
+    ).then(() => {
+      commited.name = action.name;
+      commited.script = action.script;
+      commitEnabled = false;
+    });
+  }
+</script>
+
+<div bind:this={monaco_block} class="flex w-full {autoSize ? '' : 'h-full'}" />

--- a/src/renderer/main/user-interface/CodeEditor.svelte
+++ b/src/renderer/main/user-interface/CodeEditor.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onDestroy, onMount, tick } from "svelte";
-  import { editor as MonacoApi } from "monaco-editor";
   import { GridScript, type ElementType } from "@intechstudio/grid-protocol";
   import { Grid } from "../../lib/_utils";
   import { appSettings } from "../../runtime/app-helper.store";
@@ -15,11 +14,6 @@
   // Autocomplete scope (element type), passed through to Monaco.
   export let restrictScope: ElementType | undefined = undefined;
   export let readOnly = false;
-  // Auto-size the editor to its content, clamped between minLines and maxLines
-  // (content scrolls past maxLines). When maxLines is undefined the editor fills
-  // its parent instead. Used for the in-action-block editor.
-  export let minLines = 1;
-  export let maxLines: number | undefined = undefined;
   // Show the line-number gutter. Disabled for the compact in-action-block editor.
   export let lineNumbers = true;
   // Wrap long lines. When false, lines scroll horizontally instead.
@@ -45,11 +39,8 @@
   // Thrown for the script-length limit so it can be told apart from parse errors.
   class LengthError extends String {}
 
-  $: autoSize = maxLines !== undefined;
-
   $: if (editor) {
     editor.updateOptions({ fontSize: $appSettings.persistent.fontSize });
-    updateHeight();
   }
 
   $: if (editor) {
@@ -122,10 +113,6 @@
     });
 
     disposables.push(editor.onDidChangeModelContent(handleContentChange));
-    if (autoSize) {
-      disposables.push(editor.onDidContentSizeChange(updateHeight));
-    }
-    updateHeight();
 
     // An override may differ from the committed script, so reflect that as
     // unsaved changes right away.
@@ -156,18 +143,6 @@
     disposables.forEach((d) => d.dispose());
     editor?.dispose();
   });
-
-  // Size the editor to its content, clamped between minLines and maxLines.
-  function updateHeight() {
-    if (!autoSize || !editor) return;
-    const lineHeight = editor.getOption(MonacoApi.EditorOption.lineHeight);
-    const height = Math.min(
-      maxLines * lineHeight,
-      Math.max(minLines * lineHeight, editor.getContentHeight()),
-    );
-    monaco_block.style.height = `${height}px`;
-    editor.layout();
-  }
 
   // Validate the current editor content and recompute commit/error state.
   // The action is mutated transiently only to measure the resulting event
@@ -224,4 +199,4 @@
   }
 </script>
 
-<div bind:this={monaco_block} class="flex w-full {autoSize ? '' : 'h-full'}" />
+<div bind:this={monaco_block} class="flex w-full h-full" />

--- a/src/renderer/main/user-interface/CommitStatus.svelte
+++ b/src/renderer/main/user-interface/CommitStatus.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  // Sync state badge shared by the code editor modal and the in-action-block editor.
+  export let commitEnabled = false;
+  export let deleted = false;
+</script>
+
+{#if deleted}
+  <div class="text-right text-sm">Deleted Action</div>
+{:else}
+  <div
+    class="text-right text-sm {commitEnabled
+      ? 'text-yellow-600'
+      : 'text-green-500'}"
+  >
+    {commitEnabled ? "Unsaved changes!" : "Synced with Grid!"}
+  </div>
+{/if}

--- a/src/renderer/main/user-interface/LineEditor.svelte
+++ b/src/renderer/main/user-interface/LineEditor.svelte
@@ -148,7 +148,7 @@
 
 <div
   id="monaco_container"
-  class="grid grid-cols-1 w-full h-full items-center p-1 rounded bg-background"
+  class="grid grid-cols-1 w-full h-full items-center p-1 rounded border border-background-soft bg-background-muted"
 >
   <div
     id="line-editor"

--- a/src/renderer/main/user-interface/cursor-log/CursorLog.svelte
+++ b/src/renderer/main/user-interface/cursor-log/CursorLog.svelte
@@ -31,15 +31,19 @@
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- The container is just a positioner and must not intercept clicks (it sits
+  over the app for ~5s after every operation); only the messages themselves are
+  interactive, so pointer events are re-enabled per message below. -->
 <container
   id="cursor-log"
-  class="absolute bottom-[5rem] left-1/2 -translate-x-1/2 mb-4 z-[2]"
-  on:mouseenter={handleMouseEnter}
-  on:mouseleave={handleMouseLeave}
+  class="absolute bottom-[5rem] left-1/2 -translate-x-1/2 mb-4 z-[2] pointer-events-none"
 >
   <div class="flex flex-col w-[30rem]">
     {#each $logStreamStore as log, i (log)}
       <div
+        class="pointer-events-auto"
+        on:mouseenter={handleMouseEnter}
+        on:mouseleave={handleMouseLeave}
         in:fly|global={{ x: -10, delay: 100 + 400 * i, duration: 500 }}
         out:fly|global={{ x: 10, delay: 400 * i, duration: 500 }}
       >

--- a/src/renderer/main/user-interface/cursor-log/LogStream.store.js
+++ b/src/renderer/main/user-interface/cursor-log/LogStream.store.js
@@ -66,9 +66,18 @@ function createLogStream() {
     }
   });
 
+  // Force the log stream (and the underlying logger) back to an empty state,
+  // cancelling any pending auto-clear. Used to get rid of "bleeding" toasts
+  // that would otherwise linger for up to 5s and overlay later interactions.
+  function reset() {
+    clearTimeout(logClearTimeout);
+    clearLogs(true);
+  }
+
   return {
     ...logStream,
     dismissLog: dismissLog,
     enableTimeout: enableTimeout,
+    reset: reset,
   };
 }


### PR DESCRIPTION
Closes #1390
Closes #967

Makes working with code blocks less of a time sink by removing the need to open/close the full editor modal to switch between blocks.

## Part 1 — auto-close & replace
A new `monaco-session.store` tracks the open editor's action + dirty state. Opening another block's editor while the current one is **clean** auto-closes and replaces it; while it has **unsaved changes** it's protected and the trigger is disabled.

## Part 2 — inline editing
The read-only preview is replaced by a real inline Monaco editor in the action block, so you can edit any number of blocks without ever opening the modal.

- `Monaco.svelte` decomposed into reusable **`CodeEditor`** (editor + validation + commit), **`CommitStatus`**, and **`CharacterCount`** components, reused by both the modal and the inline editor.
- Inline editor: **Commit**/**Discard** with the modal's commit behavior, auto-sizing (5–20 lines), syntax validation, no line numbers, horizontal scroll, suggestions off.
- **Open Editor** carries uncommitted inline edits into the modal; **discard** from the modal reverts the inline editor; **commit** from either keeps the other in sync.
- The block open in the modal is locked inline with a dimmed grayscale overlay.
- Syntax errors are dispatched to `DynamicWrapper` so the block is flagged invalid (red border) like other blocks, and cleared on teardown so the flag doesn't outlive the editor.
- "Powered by Lua" footer moved into the modal.
- Replaced `svelte/animate` `flip` with a translate-only `reflow` animation so blocks whose height changes (e.g. showing a syntax error) aren't vertically squished mid-animation.
- Border/background switched to grid-uikit theme tokens (`background-muted` / `background-soft`), also applied to `LineEditor`.

## Ctrl+S to commit/save (#967)
Ctrl/Cmd+S now commits/saves in every code-editor context. Each container catches the keystroke (`preventDefault` + `stopPropagation`, so it's scoped and doesn't hit the browser default or other handlers) and triggers the context's canonical button, which no-ops on its own when disabled:

| Context | Component | Action |
|---|---|---|
| Inline code block | `CodeBlock.svelte` | Commit |
| Code editor modal | `Monaco.svelte` | Commit |
| File Manager | `FileManager.svelte` | Save |

Per the direction in #967, this is scoped to editor/file-system commits rather than a global "save everything" state. Buttons are triggered via their rendered `<button>` for now; follow-up intechstudio/grid-uikit#50 proposes a `MoltenPushButton.trigger()` method to drop the wrapper + `querySelector`.

## Notes
- The literal "double-click the preview to open" trigger from #1390 is replaced by inline editing + an **Open Editor** button (the preview no longer exists).
- Uncommitted inline edits live only in the editor buffer until Commit; collapsing/navigating away discards them (visible "Unsaved changes!" status + Commit/Discard mitigate this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)