### PR TITLE
Fix configs not loading when configs folder contains subdirectories (#1392)

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -37,18 +37,16 @@ function setupRendererLogTransport() {
                            'log';
       
       // Format the message with [ELECTRON] prefix to distinguish from renderer logs
-      const prefix = `%c[ELECTRON]%c ${scope}`;
-      const prefixStyle = 'color: #ff6b6b; font-weight: bold;';
-      const scopeStyle = scope ? 'color: #a78bfa;' : '';
-      
+      const prefix = `[ELECTRON]${scope ? " " + scope : ""}`;
+
       // Execute console log in the renderer's DevTools
-      const args = logData.map(arg => 
+      const args = logData.map(arg =>
         typeof arg === 'object' ? JSON.stringify(arg) : String(arg)
       ).join(' ');
-      
+
       // Inject the log into renderer's console
       mainWindow.webContents.executeJavaScript(
-        `console.${consoleMethod}("${prefix}", "${prefixStyle}", "${scopeStyle}", ${JSON.stringify(args)})`
+        `console.${consoleMethod}(${JSON.stringify(prefix)}, ${JSON.stringify(args)})`
       ).catch(() => {
         // Silently fail if window is closing
       });
@@ -809,8 +807,12 @@ function startConfigWatcher(configPath, rootDirectory) {
   configWatcher?.close();
 
   async function sendLocalConfigs() {
-    var result = await loadConfigsFromDirectory(configPath, rootDirectory);
-    mainWindow.webContents.send("sendConfigsToRenderer", result);
+    try {
+      var result = await loadConfigsFromDirectory(configPath, rootDirectory);
+      mainWindow.webContents.send("sendConfigsToRenderer", result);
+    } catch (e) {
+      log.error("Failed to load local configs:", e);
+    }
   }
 
   configWatcher = chokidar.watch(path.join(configPath, "configs"), {

--- a/src/electron/src/profiles.ts
+++ b/src/electron/src/profiles.ts
@@ -105,12 +105,24 @@ export async function loadConfigsFromDirectory(configPath, rootDirectory) {
   const [stats] = await checkIfWritableDirectory(`${path}/${rootDirectory}`);
 
   if (stats.isDirectory) {
-    const files = await fs.promises.readdir(`${path}/${rootDirectory}`);
+    const entries = await fs.promises.readdir(`${path}/${rootDirectory}`, {
+      withFileTypes: true,
+    });
 
-    for (const file of files) {
+    for (const entry of entries) {
+      // Only read .json files. Skip subdirectories (e.g. a .git folder when the
+      // configs folder is under source control) and other non-config files —
+      // attempting to readFile a directory throws EISDIR and would abort the
+      // whole load, leaving the user with no configs at all (issue #1392).
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        continue;
+      }
+
+      const file = entry.name;
       let filepath = path + "/" + rootDirectory + "/" + file;
 
-      await fs.promises.readFile(filepath, "utf-8").then(async (data) => {
+      try {
+        const data = await fs.promises.readFile(filepath, "utf-8");
         if (isJson(data)) {
           let obj = JSON.parse(data);
           if (obj.configType) {
@@ -128,7 +140,9 @@ export async function loadConfigsFromDirectory(configPath, rootDirectory) {
         } else {
           log.info("Not a file!");
         }
-      });
+      } catch (e) {
+        log.info(`Failed to read config file ${file}:`, e);
+      }
     }
   } else {
     log.info("Not a directory!");


### PR DESCRIPTION
## Problem

Fixes #1392. When the `grid-userdata/configs` folder contains a subdirectory — most commonly a `.git` folder when the user puts the configs under source control — **all** or some configs disappear from the editor due to a runtime error during directory read. Deleting the subdirectory makes them reappear after restarting the App.

## Root cause

`loadConfigsFromDirectory` (`src/electron/src/profiles.ts`) did a flat `readdir` and called `fs.promises.readFile()` on **every** entry with no type check and no error handling:

```ts
const files = await fs.promises.readdir(`${path}/${rootDirectory}`);
for (const file of files) {
  await fs.promises.readFile(filepath, "utf-8").then(...); // EISDIR on a directory
}
```

The moment it hit a directory entry, `readFile` rejected with `EISDIR`, the unguarded `await` threw, and the entire function rejected — so the renderer got **zero** (or some but not all) configs instead of just skipping the directory.

Reproduced against a real configs folder: the original loop threw `EISDIR`; the fixed loop loads all configs.

### Why no error showed in the console

The initial load runs in the **main** process via the watcher's fire-and-forget `sendLocalConfigs()` (no `await`, no `.catch`). The rejection became an unhandled main-process rejection, invisible to the renderer DevTools console, and `webContents.send("sendConfigsToRenderer", ...)` simply never ran — a silent empty state.

## Changes

- **`profiles.ts`**: read with `withFileTypes` and only process `.json` files, skipping subdirectories and other entries. Each read is wrapped in `try/catch` so one bad/corrupt file can't abort the rest.
- **`main.ts`**: wrap the watcher's `sendLocalConfigs()` body in `try/catch` so a load failure is logged via `log.error` instead of becoming a silent unhandled rejection.
- **`main.ts`**: drop the custom `%c` coloring on `[ELECTRON]` forwarded logs (plain prefix now).

## Testing

- Type-checks clean (`tsc --noEmit`).
- Verified the load logic against a real configs folder containing a subdirectory: original throws `EISDIR` → 0 configs; fixed → all configs load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)