### PR TITLE
Fix profile cloud save rejecting IMMEDIATE for files-less pages

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -973,7 +973,6 @@ ipcMain.handle("getLatestVideo", async (event, arg) => {
 
 // launch browser and open url
 ipcMain.handle("openInBrowser", async (event, arg) => {
-  console.log(arg.url);
   return await shell.openExternal(arg.url);
 });
 

--- a/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
+++ b/src/renderer/main/panels/profileCloud/ProfileCloud.svelte
@@ -38,6 +38,7 @@
     fetchDirEntries,
     fetchFileContent,
     pageNumberToFolderPath,
+    type DirEntry,
   } from "../FileManager/FileManager";
 
   const configuration = window.ctxProcess.configuration();
@@ -244,7 +245,12 @@
         // Get files from the selected module, under given page folder. NO recursion / traversal.
         const pageFolderPath = pageNumberToFolderPath(ui.pagenumber);
         const activeModule = active.findModule(ui.dx, ui.dy);
-        const fileEntries = await fetchDirEntries(pageFolderPath, activeModule);
+        let fileEntries: DirEntry[] = [];
+        try {
+          fileEntries = await fetchDirEntries(pageFolderPath, activeModule);
+        } catch {
+          // Directory doesn't exist yet — nothing to include
+        }
         const files: { name: string; content: string }[] = [];
 
         for (const entry of fileEntries) {


### PR DESCRIPTION
## Summary
- `handleGetCurrentConfigurationFromEditor` in `ProfileCloud.svelte` called `fetchDirEntries()` without error handling, so saving a profile from a page/module that has no file directory yet (e.g. `dirent.list` erroring on a nonexistent path) caused the underlying `IMMEDIATE` grid call to reject with `Waiting for response was interrupted`, aborting the whole save.
- Wraps the call in try/catch, falling back to an empty file list — mirrors the existing pattern already used in `clearDirFiles()` in `FileManager.ts`.

## Test plan
- [x] Save a profile to cloud from a page/module that has never had files written to it — confirm it saves successfully instead of throwing.
- [x] Save a profile from a page/module that does have files — confirm files are still fetched and included as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)