### PR TITLE
feat: multiarch firmware variant with 25% rollout

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -3,6 +3,11 @@ import App from "./App.svelte";
 import { init_config_block_library } from "./lib/_configs";
 import { initLuaFormatter } from "@intechstudio/grid-protocol";
 import { mount } from "svelte";
+import { isMultiarchGroup } from "./main/firmware_update";
+
+console.log(
+  `Multiarch group: ${isMultiarchGroup() ? "YES" : "NO"} (url: ${window.location.href})`,
+);
 
 let app;
 

--- a/src/renderer/main/firmware_update.ts
+++ b/src/renderer/main/firmware_update.ts
@@ -1,6 +1,18 @@
 import JSZip from "jszip";
 import { Analytics } from "../runtime/analytics.js";
 
+export function isMultiarchGroup(): boolean {
+  const url = window.location.href;
+  if (url.startsWith("http")) {
+    return true;
+  }
+  let hash = 0;
+  for (let i = 0; i < url.length; i++) {
+    hash = ((hash << 5) - hash + url.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0) % 100 < 25;
+}
+
 const CORS_PROXY = "https://api.cors.lol/?url=";
 
 let status = "";

--- a/src/renderer/main/modals/FirmwareUpdate.svelte
+++ b/src/renderer/main/modals/FirmwareUpdate.svelte
@@ -32,6 +32,7 @@
   import {
     getGridRecommendedFirmwareUrl,
     fetchAndExtract,
+    isMultiarchGroup,
   } from "../firmware_update.ts";
   import ManualFirmwareOptions from "../components/ManualFirmwareOptions.svelte";
   export let data: Modal.Instance;
@@ -110,12 +111,21 @@
 
       // Find the correct firmware file based on product and architecture
       let firmwareFile = null;
+      const useMultiarch = product === "grid" && isMultiarchGroup();
+
       for (const file of uf2Files) {
         const filename = file.filename.toLowerCase();
 
         if (product === "grid") {
-          // Look for grid firmware matching the architecture
           if (
+            useMultiarch &&
+            filename.includes("multiarch") &&
+            filename.includes("grid")
+          ) {
+            firmwareFile = file;
+            break;
+          } else if (
+            !useMultiarch &&
             architecture === "esp32" &&
             filename.includes("esp32") &&
             filename.includes("grid")
@@ -123,6 +133,7 @@
             firmwareFile = file;
             break;
           } else if (
+            !useMultiarch &&
             architecture === "d51" &&
             filename.includes("d51") &&
             filename.includes("grid")
@@ -131,7 +142,6 @@
             break;
           }
         } else if (product === "knot") {
-          // Look for knot firmware
           if (filename.includes("knot")) {
             firmwareFile = file;
             break;
@@ -162,6 +172,7 @@
         event: "FirmwareCheck",
         payload: {
           message: "Firmware Download Finished",
+          filename: firmwareFile.filename,
         },
         mandatory: false,
       });


### PR DESCRIPTION
## Summary
- Adds multiarch UF2 variant support for grid firmware updates
- 25% of production users get the multiarch variant; 75% continue with architecture-specific (esp32/d51)
- Dev mode always uses multiarch for easy testing
- Tracks selected UF2 filename in Mixpanel analytics

## Changes
- **`firmware_update.ts`** — new `isMultiarchGroup()` function: hashes `window.location.href` for deterministic group assignment; always `true` for dev (`http://` URLs)
- **`FirmwareUpdate.svelte`** — UF2 selection now branches on multiarch vs architecture-specific based on group; filename added to analytics payload
- **`main.js`** — logs group membership at startup

## Testing
- Dev mode: always uses multiarch (check console for `Multiarch group: YES`)
- Production: ~25% of installs will see multiarch, based on deterministic hash of install path