### PR TITLE
Block element/event navigation while CodeBlock has uncommitted changes

### DIFF
--- a/src/renderer/config-blocks/CodeBlock.svelte
+++ b/src/renderer/config-blocks/CodeBlock.svelte
@@ -50,6 +50,7 @@
   import CodeEditor from "../main/user-interface/CodeEditor.svelte";
   import CommitStatus from "../main/user-interface/CommitStatus.svelte";
   import { appSettings } from "../runtime/app-helper.store";
+  import { setCodeBlockDirty } from "../runtime/code-block-dirty.store";
 
   export let action: GridAction;
 
@@ -84,6 +85,8 @@
   // The inline editor has uncommitted changes (edited script or a syntax error).
   $: inlineDirty = commitEnabled || errorMessage !== "";
 
+  $: setCodeBlockDirty(action.id, inlineDirty);
+
   // Propagate the inline editor's syntax-error state to the action so the
   // block is flagged invalid (red border), like other action blocks do. The
   // committed script is kept; only the validity flag is toggled.
@@ -104,6 +107,7 @@
   // can't clear it. Clear it ourselves when the editor is torn down (navigating
   // away or collapsing the block) so the block doesn't stay flagged invalid.
   onDestroy(() => {
+    setCodeBlockDirty(action.id, false);
     if (hadError) {
       dispatch("update-action", {
         short: action.information.short,

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -25,6 +25,11 @@
       elementnumber: elementNumber,
       eventtype: ui.eventtype,
     });
+
+    const after = get(user_input);
+    if (after.elementnumber !== elementNumber) {
+      selectedElementNumber = after.elementnumber;
+    }
   }
 
   $: handlePageChange($page);

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -75,6 +75,11 @@
       elementnumber: ui.elementnumber,
       eventtype: selected,
     });
+
+    const after = get(user_input);
+    if (after.eventtype !== selected) {
+      selected = after.eventtype;
+    }
   }
 
   function handleMouseLeave() {

--- a/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
+++ b/src/renderer/main/panels/configuration/components/DynamicWrapper.svelte
@@ -27,7 +27,7 @@
   import { logger } from "../../../../runtime/runtime.store";
   import { Runtime } from "../../../../runtime/string-table";
   import { get } from "svelte/store";
-  import { information } from "../../../../config-blocks/CodeBlock.svelte";
+  import { codeBlockDirty } from "../../../../runtime/code-block-dirty.store";
   import { Modal } from "../../../modals/modal.store";
   import RenameActionBlock from "../../../modals/RenameActionBlock.svelte";
 
@@ -155,6 +155,15 @@
 
   function handleToggle() {
     if (action.information.toggleable == false) {
+      return;
+    }
+    if (action.toggled && get(codeBlockDirty)) {
+      logger.set({
+        type: "alert",
+        mode: 0,
+        classname: "luanotok",
+        message: `Commit or discard changes before collapsing.`,
+      });
       return;
     }
     action.toggled = !action.toggled;

--- a/src/renderer/runtime/code-block-dirty.store.ts
+++ b/src/renderer/runtime/code-block-dirty.store.ts
@@ -1,0 +1,14 @@
+import { writable } from "svelte/store";
+
+const dirtyIds = new Set<string>();
+
+export const codeBlockDirty = writable(false);
+
+export function setCodeBlockDirty(id: string, dirty: boolean) {
+  if (dirty) {
+    dirtyIds.add(id);
+  } else {
+    dirtyIds.delete(id);
+  }
+  codeBlockDirty.set(dirtyIds.size > 0);
+}

--- a/src/renderer/runtime/runtime-manager.store.ts
+++ b/src/renderer/runtime/runtime-manager.store.ts
@@ -22,6 +22,7 @@ import {
   type SetIntervalAsyncTimer,
 } from "set-interval-async";
 import { modalManager } from "../main/modals/modal.store";
+import { codeBlockDirty } from "./code-block-dirty.store";
 import { Grid } from "../lib/_utils";
 import { GridService } from "./services";
 
@@ -233,7 +234,8 @@ export class GridRuntimeManager implements Readable<GridRuntimeManagerData> {
 
     if (
       runtime.unsavedChangesCount() != 0 ||
-      get(modalManager).windows.length > 0
+      get(modalManager).windows.length > 0 ||
+      get(codeBlockDirty)
     ) {
       // THIS IS NEEDED!
       // This determines if the Grid FW should prevent page change when unsaved

--- a/src/renderer/runtime/runtime.ts
+++ b/src/renderer/runtime/runtime.ts
@@ -28,6 +28,7 @@ import { Grid } from "../lib/_utils";
 import { type GridConnection } from "../serialport/serialport";
 import { GridRuntimeManager } from "./runtime-manager.store";
 import { user_input } from "./user-input.store";
+import { codeBlockDirty } from "./code-block-dirty.store";
 import { type ProfileCloudTypes } from "../main/panels/profileCloud/ProfileCloud";
 import { type LuaValue } from "../serialport/evaluate-parser";
 import {
@@ -2306,7 +2307,7 @@ export class GridRuntime extends RuntimeNode<RuntimeData> {
 
   public async change_page(new_page_number): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.unsavedChangesCount() != 0) {
+      if (this.unsavedChangesCount() != 0 || get(codeBlockDirty)) {
         reject(Runtime.ErrorText.PAGE_CHANGE_DISABLED);
         return;
       }

--- a/src/renderer/runtime/user-input.store.ts
+++ b/src/renderer/runtime/user-input.store.ts
@@ -6,11 +6,13 @@ import {
   type Writable,
 } from "svelte/store";
 import { Modal, modalManager } from "../main/modals/modal.store";
+import ConfirmModal from "../main/modals/ConfirmModal.svelte";
 import { appSettings } from "./app-helper.store";
 import { runtime_manager } from "./runtime-manager.store";
 import { Grid } from "../lib/_utils";
 import { selected_actions } from "./selected-actions.store";
 import { GridElement, GridEvent, GridModule, GridPage } from "./runtime";
+import { codeBlockDirty } from "./code-block-dirty.store";
 
 export type UserInputValue = {
   dx: number;
@@ -32,6 +34,7 @@ export class UserInput implements Writable<UserInputValue> {
   private _internal: Writable<UserInputValue>;
   private _changed_timestamp = 0;
   private _pendingValue: UserInputValue | null = null;
+  private _pendingNavigation: UserInputValue | null = null;
   private _rafPending = false;
 
   constructor() {
@@ -42,13 +45,16 @@ export class UserInput implements Writable<UserInputValue> {
     const element = value.parent as GridElement;
     const page = element.parent as GridPage;
     const module = page.parent as GridModule;
-    this.set({
-      dx: module.dx,
-      dy: module.dy,
-      pagenumber: page.pageNumber,
-      elementnumber: element.elementIndex,
-      eventtype: value.type,
-    });
+    this.set(
+      {
+        dx: module.dx,
+        dy: module.dy,
+        pagenumber: page.pageNumber,
+        elementnumber: element.elementIndex,
+        eventtype: value.type,
+      },
+      true,
+    );
 
     // Wait for next re-render
     await new Promise<void>((resolve) =>
@@ -79,29 +85,41 @@ export class UserInput implements Writable<UserInputValue> {
           element.events.map((e) => e.type),
           value.eventtype,
         );
-        this.set({
-          dx: value.dx,
-          dy: value.dy,
-          pagenumber: value.pagenumber,
-          elementnumber: value.elementnumber,
-          eventtype: closestEvent,
-        });
+        this.set(
+          {
+            dx: value.dx,
+            dy: value.dy,
+            pagenumber: value.pagenumber,
+            elementnumber: value.elementnumber,
+            eventtype: closestEvent,
+          },
+          true,
+        );
       }
     } else {
-      this.set(UserInput.defaultValue);
+      this.set(UserInput.defaultValue, true);
     }
 
     return this._internal.subscribe(run, invalidate);
   }
 
   // Set the entire object
-  public set(value: UserInputValue) {
+  public set(value: UserInputValue, force = false) {
+    if (!force && get(codeBlockDirty)) {
+      this._showDiscardModal(value);
+      return;
+    }
     this._internal.set(value);
     selected_actions.set([]);
   }
 
   // Update the object with a partial update function
-  public update(updater: Updater<UserInputValue>) {
+  public update(updater: Updater<UserInputValue>, force = false) {
+    if (!force && get(codeBlockDirty)) {
+      const current = get(this._internal);
+      this._showDiscardModal(updater(current));
+      return;
+    }
     this._internal.update(updater);
     selected_actions.set([]);
   }
@@ -109,6 +127,11 @@ export class UserInput implements Writable<UserInputValue> {
   private _flushPending() {
     this._rafPending = false;
     if (this._pendingValue !== null) {
+      if (get(codeBlockDirty)) {
+        this._showDiscardModal(this._pendingValue);
+        this._pendingValue = null;
+        return;
+      }
       this._internal.set(this._pendingValue);
       this._pendingValue = null;
       selected_actions.set([]);
@@ -121,6 +144,30 @@ export class UserInput implements Writable<UserInputValue> {
       this._rafPending = true;
       requestAnimationFrame(() => this._flushPending());
     }
+  }
+
+  private _showDiscardModal(target: UserInputValue) {
+    this._pendingNavigation = target;
+    const confirmModal = new Modal.Window(ConfirmModal, Modal.Snap.Full, {
+      showAsUnique: true,
+    });
+    confirmModal.show({
+      buttons: [
+        {
+          text: "Discard Changes & Navigate",
+          style: "outlined",
+          handler: () => {
+            const nav = this._pendingNavigation;
+            this._pendingNavigation = null;
+            confirmModal.close();
+            if (nav) {
+              this.set(nav, true);
+            }
+          },
+          focused: true,
+        },
+      ],
+    });
   }
 
   // Process incoming events
@@ -202,15 +249,18 @@ export class UserInput implements Writable<UserInputValue> {
     if (dx === ui.dx && dy === ui.dy) {
       const active = get(runtime_manager).active.runtime;
       if (active.modules.length > 0) {
-        this.set({
-          dx: active.modules[0].dx,
-          dy: active.modules[0].dy,
-          pagenumber: ui.pagenumber,
-          elementnumber: 0,
-          eventtype: ui.eventtype,
-        });
+        this.set(
+          {
+            dx: active.modules[0].dx,
+            dy: active.modules[0].dy,
+            pagenumber: ui.pagenumber,
+            elementnumber: 0,
+            eventtype: ui.eventtype,
+          },
+          true,
+        );
       } else {
-        this.set(UserInput.defaultValue);
+        this.set(UserInput.defaultValue, true);
       }
     }
   }


### PR DESCRIPTION
- Add code-block-dirty.store with Set-based tracking for multiple instances
- Guard UserInput.set/update/flushPending with ConfirmModal prompt
- Revert radio/dropdown selection when navigation is blocked
- Block collapsing DynamicWrapper when code block has unsaved edits