### PR TITLE
fix: element name empty string fallback + perf: remove redundant notifyParent

### DIFF
--- a/src/renderer/main/panels/configuration/Configuration.svelte
+++ b/src/renderer/main/panels/configuration/Configuration.svelte
@@ -192,7 +192,7 @@
         setElementNameDisplay("");
       }
       if (el.name) {
-        el.name = "";
+        el.name = undefined;
       }
     }
   }

--- a/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
+++ b/src/renderer/main/panels/configuration/ElementSelectionPanel.svelte
@@ -40,7 +40,7 @@
 
     let newOptions = elements.map((e) => {
       const stringName = e.name;
-      if (typeof stringName !== "undefined") {
+      if (typeof stringName !== "undefined" && stringName !== "") {
         return {
           title:
             stringName +

--- a/src/renderer/runtime/runtime.ts
+++ b/src/renderer/runtime/runtime.ts
@@ -317,8 +317,6 @@ abstract class RuntimeNode<T extends NodeData> implements Writable<T> {
       store[key] = value;
       return store;
     });
-
-    this.notifyParent();
   }
 }
 


### PR DESCRIPTION
## Changes

### 1. Fix element name not rendering auto-generated value when set to empty string

When an element's name store held `""` instead of `undefined`, the auto-generated fallback name (e.g. "Element 0 (Encoder)") was not rendered.

- **Configuration.svelte**: Changed `el.name = ""` to `el.name = undefined` when the name block is removed, matching the type definition (`string | undefined`) and what `resetName()` does.
- **ElementSelectionPanel.svelte**: Added `!== ""` guard alongside the existing `typeof !== "undefined"` check so empty strings also fall through to `getHumanName()`.

### 2. Perf: Remove redundant notifyParent in setField

`setField` called `this.update()` (which already calls `notifyParent()`), then called `notifyParent()` again — every field change fired two full walks up the runtime tree instead of one.

This halved store notification traffic across the entire codebase. Particularly impactful for the element name textbox, where `updateData` changes 4-5 fields per keystroke, each previously triggering ~2 walks x 5 tree levels.
