### PR TITLE
Fix Linux AppImage launch failure (libfuse2) + per-arch artifact name

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -17,6 +17,20 @@ const config = {
   productName: productNameByWorkflow(),
   copyright: "Copyright © Intech Studio Ltd.",
   generateUpdatesFilesForAllChannels: true,
+  // Use the modern AppImage toolset/runtime (electron-builder "1.0.2",
+  // runtime 20251108) instead of the legacy default ("0.0.0").
+  //
+  // The legacy runtime dynamically links libfuse.so.2 to self-mount its
+  // squashfs. Manjaro/Arch and current Ubuntu (23.10 / 24.04+) no longer
+  // ship libfuse2 by default, so the mount fails and the runtime dies with
+  // "execv error: Transport endpoint is not connected" (ENOTCONN) or
+  // "execv error: Input/output error" (EIO) before the app ever starts.
+  // The 1.0.2 toolset bundles the FUSE libraries inside the AppImage
+  // (usr/lib), removing the host libfuse2 dependency. Flatpak was never
+  // affected because it doesn't use the AppImage/FUSE runtime.
+  toolsets: {
+    appimage: "1.0.2",
+  },
   directories: {
     output: "build/",
     buildResources: "build-assets",
@@ -70,7 +84,14 @@ const config = {
     // `electron-builder --linux flatpak` (see e:builder:flatpak script),
     // so it never runs implicitly on machines without flatpak-builder.
     target: "AppImage",
-    artifactName: "${name}-linux-${version}.${ext}",
+    // ${arch} is required: the matrix builds AppImages on both x64
+    // (ubuntu-22.04) and arm64 (ubuntu-22.04-arm) runners, and the release
+    // publish step downloads every artifact into one directory with
+    // merge-multiple. Without the arch token both builds share a filename
+    // and silently overwrite each other, so users can receive the wrong-arch
+    // binary. The per-arch update channels (latest-linux.yml /
+    // latest-linux-arm64.yml) also each reference their own file this way.
+    artifactName: "${name}-linux-${version}-${arch}.${ext}",
     category: "Audio",
     synopsis: "Editor software for Intech Studio Grid controllers",
     desktop: {


### PR DESCRIPTION
## Problem

Since the Linux build pipeline changed, users report the AppImage failing to launch:

- Manjaro: `execv error: Transport endpoint is not connected` (ENOTCONN)
- Ubuntu: `execv error: Input/output error` (EIO)

Flatpak builds are unaffected.

## Root cause

**1. Legacy FUSE2 AppImage runtime.** electron-builder 26.8's `toolsets.appimage` defaults to `"0.0.0"`, which uses the legacy runtime (`buildFuse2AppImage`). That runtime dynamically links `libfuse.so.2` to self-mount its embedded squashfs. Manjaro/Arch and current Ubuntu (23.10 / 24.04+) no longer ship `libfuse2` by default, so the mount never comes up → accessing `AppRun` at the dead mountpoint returns ENOTCONN / EIO → the runtime prints `execv error: <errno>` before the app starts. Flatpak doesn't use the AppImage/FUSE runtime, so it was never affected.

**2. `artifactName` missing `${arch}`.** The matrix builds AppImages on both `ubuntu-22.04` (x64) and `ubuntu-22.04-arm` (arm64). The publish job downloads all artifacts into one directory with `merge-multiple: true`, so both builds shared the filename `grid-editor-linux-<ver>.AppImage` and silently overwrote each other — one arch's users could get the wrong-arch binary.

## Fix

- Set `toolsets.appimage: "1.0.2"` (runtime 20251108). This toolset bundles the FUSE libraries **inside** the AppImage (`usr/lib`), removing the host `libfuse2` dependency.
- Add `${arch}` to `linux.artifactName` so x64/arm64 keep distinct filenames.

## Auto-update: verified safe

Checked against the installed `electron-updater`:

- Update file is selected by **extension** (`findFile(..., "AppImage", ...)`), not by filename — the rename doesn't affect selection.
- Each arch already reads its **own** channel file (`getChannelFilePrefix()`: x64 → `latest-linux.yml`, arm64 → `latest-linux-arm64.yml`), and electron-builder regenerates those pointing at the new arch-specific files. This actually **repairs** the prior collision where both channels referenced a single overwritten AppImage.
- Differential (blockmap) updates keep working: the version string is substituted per update while the arch token stays constant. The first hop from an old no-arch build falls back to a full download, which is the normal safe fallback.

## Note

`toolsets.appimage: "1.0.2"` is marked **beta** in electron-builder. Recommend validating a produced AppImage on a clean Manjaro / Ubuntu 24.04 box **without** `libfuse2` installed before the release goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)