### PR TITLE
fix(file-manager): shortify/humanize Lua files on save/read

### DIFF
--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -4,7 +4,6 @@
   import { MoltenPushButton, MeltSelect } from "@intechstudio/grid-uikit";
   import { runtime_manager } from "../../../runtime/runtime-manager.store";
   import type { GridRuntime } from "../../../runtime/runtime";
-  import { grid, GridScript } from "@intechstudio/grid-protocol";
   import type { ModuleType } from "@intechstudio/grid-protocol";
   import { MonacoEditor } from "../../../lib/monaco";
   import { appSettings } from "../../../runtime/app-helper.store";
@@ -19,6 +18,11 @@
     copyFile,
     deleteFile,
   } from "./FileManager";
+  import {
+    toDeviceContent,
+    toEditorContent,
+    LUA_LANGUAGE_ID,
+  } from "./lua-transform";
   import * as monaco from "monaco-editor";
   import {
     openEditorContext,
@@ -161,10 +165,7 @@
   $: contentInfo = (() => {
     if (!fileContent || !selectedEntry) return null;
     try {
-      const content =
-        selectedLanguage === "lua"
-          ? GridScript.compressScript(fileContent)
-          : fileContent;
+      const content = toDeviceContent(fileContent, selectedLanguage);
       luaSyntaxError = null;
       const bytes = content.length;
       const chunks = Math.max(1, Math.ceil(bytes / CHUNK_SIZE));
@@ -198,12 +199,12 @@
 
   const languageOptions = [
     { title: "Plain Text", value: "plaintext" },
-    { title: "Lua", value: "intech_lua" },
+    { title: "Lua", value: LUA_LANGUAGE_ID },
     { title: "TOML", value: "ini" },
   ];
 
   const extLanguageMap: Record<string, string> = {
-    lua: "intech_lua",
+    lua: LUA_LANGUAGE_ID,
     toml: "ini",
   };
 
@@ -219,10 +220,7 @@
     if (model) monaco.editor.setModelLanguage(model, selectedLanguage);
     if (rawContent !== null) {
       try {
-        const recalculated =
-          selectedLanguage === "lua"
-            ? GridScript.expandScript(rawContent)
-            : rawContent;
+        const recalculated = toEditorContent(rawContent, selectedLanguage);
         fileContent = recalculated;
         savedContent = recalculated;
         editor.setValue(recalculated);
@@ -319,10 +317,7 @@
       rawContent = assembled;
       selectedLanguage = detectLanguage(entry);
       try {
-        fileContent =
-          selectedLanguage === "lua"
-            ? GridScript.expandScript(rawContent)
-            : rawContent;
+        fileContent = toEditorContent(rawContent, selectedLanguage);
         luaSyntaxError = null;
       } catch (e) {
         fileContent = rawContent;
@@ -350,10 +345,7 @@
 
       let content: string;
       try {
-        content =
-          selectedLanguage === "lua"
-            ? GridScript.compressScript(fileContent)
-            : fileContent;
+        content = toDeviceContent(fileContent, selectedLanguage);
       } catch (e) {
         error = `Syntax error: ${e}`;
         return;

--- a/src/renderer/main/panels/FileManager/lua-transform.ts
+++ b/src/renderer/main/panels/FileManager/lua-transform.ts
@@ -1,0 +1,37 @@
+import { GridScript } from "@intechstudio/grid-protocol";
+
+// Pure, dependency-free transforms for the file manager's Lua editor. Kept
+// separate from FileManager.ts (which pulls in runtime/serialport types) so
+// they can be unit-tested without dragging in the app graph.
+
+/**
+ * Monaco language id for Grid Lua files. The editor shows the human-readable
+ * form; the module only understands the short API names. This is the single
+ * source of truth for that id — the transform helpers and the language map
+ * both reference it so the two can never drift apart (a past drift between
+ * "lua" and "intech_lua" silently disabled the transforms entirely).
+ */
+export const LUA_LANGUAGE_ID = "intech_lua";
+
+/**
+ * Editor content -> content written to the module. For Lua, translate the
+ * human-readable Grid API names to the short names the firmware exposes
+ * (e.g. `draw_rectangle_filled` -> `ldrf`); other content passes through.
+ *
+ * Name translation only — no minification — mirroring the action-block code
+ * editors' postProcessor (GridScript.shortify). Minify is a send-time size
+ * optimization for single-packet execution; files are chunk-written and
+ * `require()`d, so keeping formatting and comments intact is preferable.
+ */
+export function toDeviceContent(content: string, language: string): string {
+  return language === LUA_LANGUAGE_ID ? GridScript.shortify(content) : content;
+}
+
+/**
+ * Inverse of {@link toDeviceContent}: expand short Grid API names back to
+ * their human-readable form for display. Mirrors the config editors'
+ * preProcessor (GridScript.humanize).
+ */
+export function toEditorContent(content: string, language: string): string {
+  return language === LUA_LANGUAGE_ID ? GridScript.humanize(content) : content;
+}

--- a/src/renderer/tests/file-manager-transform.test.js
+++ b/src/renderer/tests/file-manager-transform.test.js
@@ -1,0 +1,42 @@
+import { test, expect } from "vitest";
+import {
+  toDeviceContent,
+  toEditorContent,
+  LUA_LANGUAGE_ID,
+} from "../main/panels/FileManager/lua-transform";
+
+// Regression guard: a drift between the language id used to tag .lua files
+// ("intech_lua") and the id the transforms checked for ("lua") silently
+// disabled shortify/humanize, so human-readable Grid API names were written
+// verbatim and failed on device ("attempt to call a nil value").
+
+test("Lua save shortifies human-readable Grid API names", () => {
+  const human = "scr:draw_rectangle_filled(0, 0, 10, 10, C_BG)";
+  const onDevice = toDeviceContent(human, LUA_LANGUAGE_ID);
+  expect(onDevice).toContain(":ldrf(");
+  expect(onDevice).not.toContain("draw_rectangle_filled");
+});
+
+test("Lua read humanizes short Grid API names", () => {
+  const onDevice = "scr:ldrf(0,0,10,10,C_BG)";
+  const human = toEditorContent(onDevice, LUA_LANGUAGE_ID);
+  expect(human).toContain(":draw_rectangle_filled(");
+  expect(human).not.toContain(":ldrf(");
+});
+
+test("Lua transforms preserve formatting (no minification)", () => {
+  const human = "-- comment\nlocal x = 1\nscr:draw_text('hi', 0, 0, 1, C)\n";
+  const onDevice = toDeviceContent(human, LUA_LANGUAGE_ID);
+  // names translated, but newlines and the comment survive
+  expect(onDevice).toContain("-- comment");
+  expect(onDevice.split("\n").length).toBe(human.split("\n").length);
+  expect(onDevice).toContain(":ldt(");
+});
+
+test("Non-Lua content passes through untouched", () => {
+  const toml = "draw_rectangle_filled = 5\n";
+  expect(toDeviceContent(toml, "ini")).toBe(toml);
+  expect(toEditorContent(toml, "ini")).toBe(toml);
+  expect(toDeviceContent(toml, "plaintext")).toBe(toml);
+  expect(toEditorContent(toml, "plaintext")).toBe(toml);
+});


### PR DESCRIPTION
The file manager tagged `.lua` files as `intech_lua`, but the save/read transforms compared `selectedLanguage === "lua"` — never true. So every branch fell through: human-readable Grid API names (e.g. `draw_rectangle_filled`) were written to modules verbatim and failed at runtime (`attempt to call a nil value`), and device files were shown without humanizing.

**Fix:** route `.lua` save/read through `GridScript.shortify` / `humanize` — name translation only, matching the action-block code editors (no minify/beautify, so formatting and comments are preserved). The language id + transforms are centralized in `lua-transform.ts` so the id can't drift again.

Tests: `file-manager-transform.test.js` (shortify on save, humanize on read, formatting preserved, non-Lua passthrough). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)