### PR TITLE
fix(file-manager): Lua file upload — shortify + minify on save, expand on read

### DIFF
--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -26,7 +26,7 @@
     closeEditorContext,
   } from "../../../lib/monaco-luals-client";
 
-  // Monaco language id for Grid Lua files. 
+  // Monaco language id for Grid Lua files.
   const LUA_LANGUAGE_ID = "intech_lua";
 
   let selectedModule: string = "";

--- a/src/renderer/main/panels/FileManager/FileManager.svelte
+++ b/src/renderer/main/panels/FileManager/FileManager.svelte
@@ -18,12 +18,16 @@
     renameEntry,
     copyFile,
     deleteFile,
+    type DirEntry,
   } from "./FileManager";
   import * as monaco from "monaco-editor";
   import {
     openEditorContext,
     closeEditorContext,
   } from "../../../lib/monaco-luals-client";
+
+  // Monaco language id for Grid Lua files. 
+  const LUA_LANGUAGE_ID = "intech_lua";
 
   let selectedModule: string = "";
   let moduleOptions: Array<{ title: string; value: string }> = [];
@@ -162,7 +166,7 @@
     if (!fileContent || !selectedEntry) return null;
     try {
       const content =
-        selectedLanguage === "lua"
+        selectedLanguage === LUA_LANGUAGE_ID
           ? GridScript.compressScript(fileContent)
           : fileContent;
       luaSyntaxError = null;
@@ -198,12 +202,12 @@
 
   const languageOptions = [
     { title: "Plain Text", value: "plaintext" },
-    { title: "Lua", value: "intech_lua" },
+    { title: "Lua", value: LUA_LANGUAGE_ID },
     { title: "TOML", value: "ini" },
   ];
 
   const extLanguageMap: Record<string, string> = {
-    lua: "intech_lua",
+    lua: LUA_LANGUAGE_ID,
     toml: "ini",
   };
 
@@ -220,7 +224,7 @@
     if (rawContent !== null) {
       try {
         const recalculated =
-          selectedLanguage === "lua"
+          selectedLanguage === LUA_LANGUAGE_ID
             ? GridScript.expandScript(rawContent)
             : rawContent;
         fileContent = recalculated;
@@ -230,7 +234,7 @@
         luaSyntaxError = String(e);
       }
     }
-    if (selectedLanguage === "intech_lua") {
+    if (selectedLanguage === LUA_LANGUAGE_ID) {
       if (!lualsContextUri) {
         openEditorContext("").then((uri) => {
           lualsContextUri = uri;
@@ -320,7 +324,7 @@
       selectedLanguage = detectLanguage(entry);
       try {
         fileContent =
-          selectedLanguage === "lua"
+          selectedLanguage === LUA_LANGUAGE_ID
             ? GridScript.expandScript(rawContent)
             : rawContent;
         luaSyntaxError = null;
@@ -351,7 +355,7 @@
       let content: string;
       try {
         content =
-          selectedLanguage === "lua"
+          selectedLanguage === LUA_LANGUAGE_ID
             ? GridScript.compressScript(fileContent)
             : fileContent;
       } catch (e) {


### PR DESCRIPTION
The file manager tagged `.lua` files as `intech_lua`, but the save/read transforms compared `selectedLanguage === "lua"` — never true. So human-readable Grid API names (e.g. `draw_rectangle_filled`) were uploaded to modules verbatim and failed at runtime (`attempt to call a nil value`), and device files were shown without expanding.

**Fix:** route `.lua` save through `GridScript.compressScript` (shortify + minify — compact storage for memory-constrained flash) and read through `GridScript.expandScript` (humanize + beautify) — the same pipeline the runtime uses to send code to a module. The language id is centralized in one constant so the language map and the transform gates can't drift apart again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)