### PR TITLE
Remove exposed Discord feedback webhook URL

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -36,7 +36,6 @@
   "UXP_PHOTOSHOP_URL_END": "/uxp_photoshop_release.zip",
   "LIBRARY_GITHUB_URL": "https://github.com/intechstudio/grid-profiles/archive/refs/heads/main.zip",
   "EDITOR_DOWNLOAD_URL": "https://links.intech.studio/grid-editor-download",
-  "DISCORD_FEEDBACK_WEBHOOK": "https://discord.com/api/webhooks/841993443911270431/nN2quZz5UK0lDf2kfzrqK6nlpiF8a6ZxPBXYIogYlpqmgCORKAimSEt3v9Oqrs0KrgMC",
   "NOTIFICATION_JSON_URL": "https://raw.githubusercontent.com/intechstudio/grid-editor/stable/notification.json",
   "DOCUMENTATION_REFERENCEMANUAL_URL": "https://links.intech.studio/wiki",
   "DOCUMENTATION_DISCORDSERVER_URL": "https://links.intech.studio/discord",


### PR DESCRIPTION
## Summary
- `configuration.json` had a live Discord webhook URL (`DISCORD_FEEDBACK_WEBHOOK`) committed in plaintext, publicly readable in this repo
- Removes the key/value from `configuration.json`; nothing in `src/` referenced this key, so no other code changes are needed

Fixes #1587

## Note
Deleting it from the tracked file does not invalidate the credential — it's still present in git history. The webhook should be deleted/regenerated in Discord (Server Settings → Integrations → Webhooks) regardless of this PR merging.

## Test plan
- [x] Confirmed no source file references `DISCORD_FEEDBACK_WEBHOOK` (grep across `src/`)
- [x] Verified diff only removes the one line, no other config changes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>