### PR TITLE
Rename XY module to ZONA, 9x9 LED grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.9",
       "hasInstallScript": true,
       "dependencies": {
-        "@intechstudio/grid-protocol": "1.20260714.1509",
+        "@intechstudio/grid-protocol": "1.20260824.1107",
         "@intechstudio/grid-uikit": "1.20260807.1203",
         "@intechstudio/profile-cloud-webcomponent": "1.20260714.1544",
         "adm-zip": "^0.6.0",
@@ -2820,9 +2820,9 @@
       }
     },
     "node_modules/@intechstudio/grid-protocol": {
-      "version": "1.20260714.1509",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260714.1509.tgz",
-      "integrity": "sha512-wMiHjxNv36i+5P/eAT+Mhf3GFoQHUOaGzPR4g7LOQt009QcFPJmlHfpHJtjQ3gLL+WpTZKMCtU/qQpOz1gzJ1A==",
+      "version": "1.20260824.1107",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260824.1107.tgz",
+      "integrity": "sha512-4A+9uEcKdAIwOBK56A0IjSsydDGiG8YEg6pnhn9B6AQjt0NudAKEuI13DYOy/RhtW7qIDtrNGqe9dctFUZwQew==",
       "dependencies": {
         "@wasm-fmt/lua_fmt": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@intechstudio/grid-protocol": "1.20260714.1509",
+    "@intechstudio/grid-protocol": "1.20260824.1107",
     "@intechstudio/grid-uikit": "1.20260807.1203",
     "@intechstudio/profile-cloud-webcomponent": "1.20260714.1544",
     "adm-zip": "^0.6.0",

--- a/src/renderer/lib/_utils.ts
+++ b/src/renderer/lib/_utils.ts
@@ -368,7 +368,7 @@ export namespace Grid {
       PBF4 = "PBF4",
       EF44 = "EF44",
       VSNX = "VSNX",
-      XY = "XY",
+      ZONA = "ZONA",
     }
 
     const typeToArchetypeMap = {
@@ -383,7 +383,7 @@ export namespace Grid {
       [ModuleType.VSN1L]: Module.Archetype.VSNX,
       [ModuleType.VSN1R]: Module.Archetype.VSNX,
       [ModuleType.VSN2]: Module.Archetype.VSNX,
-      [ModuleType.XY]: Module.Archetype.XY,
+      [ModuleType.ZONA]: Module.Archetype.ZONA,
     };
 
     export function toArchetype(type: ModuleType): Module.Archetype {

--- a/src/renderer/main/grid-layout/grid-modules/Device.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/Device.svelte
@@ -19,7 +19,7 @@
   import EF44 from "./devices/EF44.svelte";
   import VSNX from "./devices/VSNX.svelte";
   import OCTV from "./devices/OCTV.svelte";
-  import XY from "./devices/XY.svelte";
+  import ZONA from "./devices/ZONA.svelte";
 
   //Overlays
   import ControlNameOverlay from "./overlays/ControlNameOverlay.svelte";
@@ -99,7 +99,7 @@
     VSN1R: VSNX,
     VSN2: VSNX,
     OCTV: OCTV,
-    XY: XY,
+    ZONA: ZONA,
   };
 
   // Reactive (not onMount-only) so the preview updates if `device.type`

--- a/src/renderer/main/grid-layout/grid-modules/devices/XY.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/XY.svelte
@@ -12,7 +12,14 @@
 
   let [dx, dy] = [device?.dx, device?.dy];
 
-  let ledcolor_array = Array(25)
+  const gridSize = 9;
+  const pctPositions = Array.from(
+    { length: gridSize },
+    (_, i) => ((i + 0.5) / gridSize) * 100,
+  );
+  const segments = Array.from({ length: gridSize - 1 }, (_, i) => i);
+
+  let ledcolor_array = Array(gridSize * gridSize)
     .fill(null)
     .map(() => [0, 0, 0]);
 
@@ -57,21 +64,21 @@
         style="background: color-mix(in srgb, var(--background-soft) 30%, transparent);"
       />
       <svg class="absolute inset-0 w-full h-full pointer-events-none">
-        {#each [10, 30, 50, 70, 90] as pct}
-          {#each [0, 1, 2, 3] as seg}
+        {#each pctPositions as pct}
+          {#each segments as seg}
             <line
-              x1="calc({seg * 20 + 10}% + 4.2px)"
+              x1="calc({pctPositions[seg]}% + 4.2px)"
               y1="{pct}%"
-              x2="calc({seg * 20 + 30}% - 4.2px)"
+              x2="calc({pctPositions[seg + 1]}% - 4.2px)"
               y2="{pct}%"
               stroke="color-mix(in srgb, var(--foreground) 15%, transparent)"
               stroke-width="1"
             />
             <line
               x1="{pct}%"
-              y1="calc({seg * 20 + 10}% + 4.2px)"
+              y1="calc({pctPositions[seg]}% + 4.2px)"
               x2="{pct}%"
-              y2="calc({seg * 20 + 30}% - 4.2px)"
+              y2="calc({pctPositions[seg + 1]}% - 4.2px)"
               stroke="color-mix(in srgb, var(--foreground) 15%, transparent)"
               stroke-width="1"
             />
@@ -79,14 +86,15 @@
         {/each}
       </svg>
       {#each ledcolor_array as color, i}
-        {@const col = i % 5}
-        {@const row = Math.floor(i / 5)}
+        {@const col = i % gridSize}
+        {@const row = Math.floor(i / gridSize)}
         <div
           class="absolute"
-          style="left: {col * 20 + 10}%; top: {row * 20 +
-            10}%; transform: translate(-50%, -50%);"
+          style="left: {pctPositions[col]}%; top: {pctPositions[
+            row
+          ]}%; transform: translate(-50%, -50%);"
         >
-          <Led {color} size={1.4} />
+          <Led {color} size={0.8} />
         </div>
       {/each}
     </div>

--- a/src/renderer/main/grid-layout/grid-modules/devices/ZONA.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/ZONA.svelte
@@ -3,7 +3,7 @@
   import { GridModule, GridRuntime } from "../../../../runtime/runtime.js";
 
   export let moduleWidth;
-  export let id = "XY";
+  export let id = "ZONA";
   export let device: GridModule;
 
   let runtime = device.parent as GridRuntime;

--- a/src/renderer/main/modals/AddVirtualModule.svelte
+++ b/src/renderer/main/modals/AddVirtualModule.svelte
@@ -4,7 +4,7 @@
   import EF44 from "./../grid-layout/grid-modules/devices/EF44.svelte";
   import VSNX from "./../grid-layout/grid-modules/devices/VSNX.svelte";
   import OCTV from "./../grid-layout/grid-modules/devices/OCTV.svelte";
-  import XY from "./../grid-layout/grid-modules/devices/XY.svelte";
+  import ZONA from "./../grid-layout/grid-modules/devices/ZONA.svelte";
 
   import { ModuleType } from "@intechstudio/grid-protocol";
   import { Analytics } from "./../../runtime/analytics.js";
@@ -79,9 +79,9 @@
       hwcfg: 123,
     },
     {
-      id: ModuleType.XY,
-      type: ModuleType.XY,
-      component: XY,
+      id: ModuleType.ZONA,
+      type: ModuleType.ZONA,
+      component: ZONA,
       hwcfg: 161,
     },
   ];

--- a/src/renderer/main/panels/configuration/EventPanel.svelte
+++ b/src/renderer/main/panels/configuration/EventPanel.svelte
@@ -40,11 +40,15 @@
       return;
     }
 
-    const prefiltered = element.events.filter(
-      (e) =>
-        (e.getName() !== "Setup" && e.getName() !== "Timer") ||
-        $appSettings.persistent.userLevelMinimalist === false,
+    const withoutSetupAndTimer = element.events.filter(
+      (e) => e.getName() !== "Setup" && e.getName() !== "Timer",
     );
+
+    const prefiltered =
+      $appSettings.persistent.userLevelMinimalist === false ||
+      withoutSetupAndTimer.length === 0
+        ? element.events
+        : withoutSetupAndTimer;
 
     options = prefiltered.map((e: GridEvent) =>
       Object({


### PR DESCRIPTION
## Summary
- Renders the module's LED matrix as a 9x9 grid (81 LEDs) instead of 5x5 (25), matching the real firmware LED count (`grid_led_init(led, 81, ...)` in grid-fw).
- Renames the `XY` module to `ZONA` throughout the editor, following the same rename already shipped in `grid-fw` (merged) and `@intechstudio/grid-protocol` (published as `1.20260824.1107`, bumped here): `Device.svelte` component registry, `AddVirtualModule.svelte` picker, `Module.Archetype` enum in `_utils.ts`, and `XY.svelte` → `ZONA.svelte`.
- Fixes `EventPanel.svelte`: minimalist mode unconditionally hid the "Setup" and "Timer" events, which left ZONA's touch element (now trimmed to just Setup + Timer, matching firmware) with zero events shown. The filter now falls back to showing all events whenever the minimalist filter would empty the list — no change for other element types, which always have a non-Setup/Timer event to fall back to.

## Test plan
- [x] `npm test` passes
- [x] `npm run web-build` compiles cleanly
- [x] Manually verified in the running app (fresh boot): Add Virtual Module → ZONA creates a 9x9 LED module with no console errors
- [x] Verified touch element shows only Setup/Timer events, and both remain visible with Minimalist mode on
- [x] Verified no regression: a Button element still collapses to just its main event in Minimalist mode