### PR TITLE
Fix ZONA LED grid order to match physical serpentine wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.9",
       "hasInstallScript": true,
       "dependencies": {
-        "@intechstudio/grid-protocol": "1.20260824.1107",
+        "@intechstudio/grid-protocol": "1.20260825.1135",
         "@intechstudio/grid-uikit": "1.20260807.1203",
         "@intechstudio/profile-cloud-webcomponent": "1.20260714.1544",
         "adm-zip": "^0.6.0",
@@ -2820,9 +2820,9 @@
       }
     },
     "node_modules/@intechstudio/grid-protocol": {
-      "version": "1.20260824.1107",
-      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260824.1107.tgz",
-      "integrity": "sha512-4A+9uEcKdAIwOBK56A0IjSsydDGiG8YEg6pnhn9B6AQjt0NudAKEuI13DYOy/RhtW7qIDtrNGqe9dctFUZwQew==",
+      "version": "1.20260825.1135",
+      "resolved": "https://registry.npmjs.org/@intechstudio/grid-protocol/-/grid-protocol-1.20260825.1135.tgz",
+      "integrity": "sha512-aRucpaz8XBMze1s3Vhx8lhpMsSwvsxjrs8MpB7yXkT+kcKItfrOY2/Qd1CqFubu2xJI0YI73UxyZM8IDDkyWrQ==",
       "dependencies": {
         "@wasm-fmt/lua_fmt": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@intechstudio/grid-protocol": "1.20260824.1107",
+    "@intechstudio/grid-protocol": "1.20260825.1135",
     "@intechstudio/grid-uikit": "1.20260807.1203",
     "@intechstudio/profile-cloud-webcomponent": "1.20260714.1544",
     "adm-zip": "^0.6.0",

--- a/src/renderer/main/grid-layout/grid-modules/devices/ZONA.svelte
+++ b/src/renderer/main/grid-layout/grid-modules/devices/ZONA.svelte
@@ -86,8 +86,9 @@
         {/each}
       </svg>
       {#each ledcolor_array as color, i}
-        {@const col = i % gridSize}
         {@const row = Math.floor(i / gridSize)}
+        {@const rawCol = i % gridSize}
+        {@const col = row % 2 === 0 ? gridSize - 1 - rawCol : rawCol}
         <div
           class="absolute"
           style="left: {pctPositions[col]}%; top: {pctPositions[


### PR DESCRIPTION
## Summary
- The ZONA 9x9 LED grid's physical wiring is serpentine (boustrophedon), not a straight row-major raster.
- `ZONA.svelte` was mapping LED index `i` to grid position with a plain `col = i % gridSize`, which doesn't reverse column order on alternating rows.
- Now alternate rows reverse column order to match the physical wiring, so the on-screen LED grid reflects hardware LED positions correctly.

## Test plan
- [ ] Connect a ZONA module and confirm LED color feedback appears in the correct grid cell for LEDs across even and odd rows
- [ ] `npm run web-build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)