### PR TITLE
Fix virtual flag drop in sendRawDataToGrid

### DIFF
--- a/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendEvaluate.svelte
@@ -99,6 +99,7 @@
         {
           dx: target.dx,
           dy: target.dy,
+          virtual: runtime.virtual,
           responseRequired: true,
           filter: {
             class_name: "EVALUATE",

--- a/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
+++ b/src/renderer/main/panels/DebugMonitor/SendRaw.svelte
@@ -60,7 +60,7 @@
     try {
       await runtime.connection.buffer.sendRawDataToGrid(
         new Uint8Array(messageArray),
-        { dx: target.dx, dy: target.dy },
+        { dx: target.dx, dy: target.dy, virtual: runtime.virtual },
       );
     } catch (e) {
       console.warn("Failed to send raw packet:", e);

--- a/src/renderer/runtime/engine.store.ts
+++ b/src/renderer/runtime/engine.store.ts
@@ -266,6 +266,7 @@ export class WriteBuffer implements Readable<WriteBufferData> {
     options?: {
       dx?: number;
       dy?: number;
+      virtual?: boolean;
       responseRequired?: boolean;
       filter?: any;
       responseTimeout?: number;
@@ -273,7 +274,7 @@ export class WriteBuffer implements Readable<WriteBufferData> {
   ): Promise<any> {
     const bufferElement: BufferElement = {
       id: 0,
-      virtual: false,
+      virtual: options?.virtual ?? false,
       rawBytes: data,
       descr: {
         brc_parameters: { DX: options?.dx ?? -127, DY: options?.dy ?? -127 },

--- a/src/renderer/serialport/instructions.ts
+++ b/src/renderer/serialport/instructions.ts
@@ -542,6 +542,7 @@ export namespace GridInstruction {
         .sendRawDataToGrid(new Uint8Array(messageArray), {
           dx: this.dx,
           dy: this.dy,
+          virtual: this.simulate,
           responseRequired: true,
           filter: {
             class_name: "EVALUATE",


### PR DESCRIPTION
## Summary
`sendRawDataToGrid()` hardcoded `virtual: false`, so `SendLuaImmediateAndEvaluate` (the Lua immediate-exec instruction backing all `FileManager.ts` file I/O) always routed to the real transport instead of `ConnectionSimulator` when called against a virtual module. Since virtual modules have no real transport, this hung for a 5s timeout on every call.

Profile Cloud's "save profile" flow calls this path (via `fetchDirEntries`/`fetchFileContent`) to bundle a page's files, so every virtual-module profile save stalled ~5s before falling back to an empty file list.

## Fix
Thread the existing `virtual` flag through `sendRawDataToGrid` and its callers (`SendLuaImmediateAndEvaluate`, plus the two DebugMonitor raw/evaluate send panels) instead of dropping it. Virtual modules now hit `ConnectionSimulator`, which correctly fast-rejects unsupported file ops instead of timing out.

## Scope / non-goals
This restores instant, correct saving of the non-file part of a profile (element/event config) on virtual modules. It does **not** add file support for virtual modules — `ConnectionSimulator` has no virtual filesystem, so file listing/reading on virtual modules still fails, just immediately instead of after a 5s hang. That's tracked as separate follow-up work.

## Test plan
- [ ] Add a virtual module, edit a page, save it as a profile via Profile Cloud — confirm it saves without the ~5s stall
- [ ] Confirm physical-module profile save/file management is unaffected
- [ ] Confirm DebugMonitor SendRaw/SendEvaluate panels behave correctly against both virtual and physical targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)