### PR TITLE
Fix TypeError when restarting AppImage build

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1197,7 +1197,7 @@ function restartApp() {
   log.info("main", "App restart requested");
 
   if (process.env.APPIMAGE) {
-    let options;
+    let options = {};
     options.args = process.argv.slice(1).concat(["--relaunch"]);
     options.execPath = process.execPath;
     options.execPath = process.env.APPIMAGE;


### PR DESCRIPTION
Fix `restartApp` in `src/electron/main.ts`: `options` was declared without initialization, so `options.args = ...` threw `TypeError: Cannot set properties of undefined (setting 'args')` on AppImage builds when restarting (Ctrl+R / Ctrl+Shift+R).